### PR TITLE
UAT round 3 hotfix — BF-32 RLS fix + BF-38 user sync + BF-39 NDOT edit + BF-41 waterway placeholder

### DIFF
--- a/src/app/dashboard/projects/[id]/forms/dust-log/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/dust-log/[submissionId]/page.tsx
@@ -173,7 +173,11 @@ export default async function DustLogViewPage({
           Add Entries
         </Link>
       </div>
-      <FormActions backHref={`/dashboard/projects/${id}?tab=daily_dust_log`} submissionId={submissionId} />
+      <FormActions
+        backHref={`/dashboard/projects/${id}?tab=daily_dust_log`}
+        submissionId={submissionId}
+        formType="daily_dust_log"
+      />
     </div>
   );
 }

--- a/src/app/dashboard/projects/[id]/forms/ndep-sad/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/ndep-sad/[submissionId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import FormActions from "@/components/form-actions";
+import { getCurrentUser } from "@/lib/auth";
 import { getProjectById, getSubmissionById } from "@/lib/queries/projects";
 import {
   NDEP_SAD_APPLICATION_TYPES,
@@ -64,12 +65,15 @@ export default async function NdepSadViewPage({
 }) {
   const { id, submissionId } = await params;
 
-  const [project, submission] = await Promise.all([
+  const [project, submission, user] = await Promise.all([
     getProjectById(id),
     getSubmissionById(submissionId),
+    getCurrentUser(),
   ]);
 
   if (!project || !submission) notFound();
+
+  const canEdit = user?.role === "admin";
 
   const data: NdepSadData | null =
     submission.data && typeof submission.data === "object" && !Array.isArray(submission.data)
@@ -244,7 +248,12 @@ export default async function NdepSadViewPage({
       </section>
 
       {/* Actions */}
-      <FormActions backHref={`/dashboard/projects/${id}?tab=ndep_sad_application`} submissionId={submissionId} />
+      <FormActions
+        backHref={`/dashboard/projects/${id}?tab=ndep_sad_application`}
+        submissionId={submissionId}
+        formType="ndep_sad_application"
+        canEdit={canEdit}
+      />
     </div>
   );
 }

--- a/src/app/dashboard/projects/[id]/forms/ndep-stormwater/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/ndep-stormwater/[submissionId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import FormActions from "@/components/form-actions";
+import { getCurrentUser } from "@/lib/auth";
 import { getProjectById, getSubmissionById } from "@/lib/queries/projects";
 import {
   NDEP_CONTROL_MEASURES,
@@ -37,12 +38,15 @@ export default async function NdepStormwaterViewPage({
 }) {
   const { id, submissionId } = await params;
 
-  const [project, submission] = await Promise.all([
+  const [project, submission, user] = await Promise.all([
     getProjectById(id),
     getSubmissionById(submissionId),
+    getCurrentUser(),
   ]);
 
   if (!project || !submission) notFound();
+
+  const canEdit = user?.role === "admin";
 
   const ndepPermit = project.project_permits?.find(
     (p: { permit_type: string; permit_number: string | null }) =>
@@ -276,7 +280,12 @@ export default async function NdepStormwaterViewPage({
       </section>
 
       {/* Actions */}
-      <FormActions backHref={`/dashboard/projects/${id}?tab=ndep_weekly_stormwater`} submissionId={submissionId} />
+      <FormActions
+        backHref={`/dashboard/projects/${id}?tab=ndep_weekly_stormwater`}
+        submissionId={submissionId}
+        formType="ndep_weekly_stormwater"
+        canEdit={canEdit}
+      />
     </div>
   );
 }

--- a/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/edit/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/edit/page.tsx
@@ -1,0 +1,56 @@
+import { notFound, redirect } from "next/navigation";
+import { getCurrentUser } from "@/lib/auth";
+import { getProjectById, getSubmissionById } from "@/lib/queries/projects";
+import NdotStormwaterForm from "@/components/forms/ndot-stormwater/NdotStormwaterForm";
+import type { NdotStormwaterData } from "@/lib/schemas/ndot-stormwater";
+
+export default async function EditNdotStormwaterPage({
+  params,
+}: {
+  params: Promise<{ id: string; submissionId: string }>;
+}) {
+  const { id, submissionId } = await params;
+
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (user.role !== "admin") {
+    redirect(`/dashboard/projects/${id}/forms/ndot-stormwater/${submissionId}`);
+  }
+
+  const [project, submission] = await Promise.all([
+    getProjectById(id),
+    getSubmissionById(submissionId),
+  ]);
+  if (!project || !submission) notFound();
+
+  const ndotPermit = project.project_permits?.find(
+    (p: { permit_type: string; permit_number: string | null }) =>
+      p.permit_type === "stormwater_ndot",
+  );
+
+  const initialData: NdotStormwaterData | null =
+    submission.data && typeof submission.data === "object" && !Array.isArray(submission.data)
+      ? (submission.data as NdotStormwaterData)
+      : null;
+  if (!initialData) notFound();
+
+  return (
+    <div>
+      <h1 className="mb-1 text-2xl font-semibold tracking-tight text-[#233B5C] dark:text-zinc-100">
+        Edit NDOT Weekly Stormwater Inspection
+      </h1>
+      <p className="mb-6 text-sm text-zinc-500 dark:text-zinc-400">
+        {project.name} — submission {submission.form_date}
+      </p>
+      <NdotStormwaterForm
+        projectId={id}
+        projectName={project.name}
+        contractNumber={ndotPermit?.permit_number ?? ""}
+        location={project.address ?? ""}
+        submissionId={submissionId}
+        initialData={initialData}
+        cancelHref={`/dashboard/projects/${id}/forms/ndot-stormwater/${submissionId}`}
+      />
+    </div>
+  );
+}

--- a/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import FormActions from "@/components/form-actions";
+import { getCurrentUser } from "@/lib/auth";
 import { getProjectById, getSubmissionById } from "@/lib/queries/projects";
 import { signFileUrlServer } from "@/lib/supabase/signed-urls";
 import {
@@ -46,12 +47,15 @@ export default async function NdotStormwaterViewPage({
 }) {
   const { id, submissionId } = await params;
 
-  const [project, submission] = await Promise.all([
+  const [project, submission, user] = await Promise.all([
     getProjectById(id),
     getSubmissionById(submissionId),
+    getCurrentUser(),
   ]);
 
   if (!project || !submission) notFound();
+
+  const canEdit = user?.role === "admin";
 
   const ndotPermit = project.project_permits?.find(
     (p: { permit_type: string; permit_number: string | null }) =>
@@ -360,7 +364,13 @@ export default async function NdotStormwaterViewPage({
       </section>
 
       {/* Actions */}
-      <FormActions backHref={`/dashboard/projects/${id}?tab=ndot_weekly_stormwater`} submissionId={submissionId} />
+      <FormActions
+        backHref={`/dashboard/projects/${id}?tab=ndot_weekly_stormwater`}
+        submissionId={submissionId}
+        formType="ndot_weekly_stormwater"
+        editHref={`/dashboard/projects/${id}/forms/ndot-stormwater/${submissionId}/edit`}
+        canEdit={canEdit}
+      />
     </div>
   );
 }

--- a/src/app/dashboard/projects/[id]/forms/ndot-stormwater/actions.ts
+++ b/src/app/dashboard/projects/[id]/forms/ndot-stormwater/actions.ts
@@ -11,6 +11,16 @@ export type NdotStormwaterState = {
   fieldErrors?: Record<string, string[]>;
 };
 
+function collectFieldErrors(issues: { path: (string | number)[]; message: string }[]) {
+  const fieldErrors: Record<string, string[]> = {};
+  for (const issue of issues) {
+    const key = issue.path.join(".");
+    if (!fieldErrors[key]) fieldErrors[key] = [];
+    fieldErrors[key].push(issue.message);
+  }
+  return fieldErrors;
+}
+
 export async function submitNdotStormwater(
   _prevState: NdotStormwaterState,
   formData: FormData
@@ -29,13 +39,10 @@ export async function submitNdotStormwater(
   const result = ndotStormwaterSchema.safeParse(raw);
 
   if (!result.success) {
-    const fieldErrors: Record<string, string[]> = {};
-    for (const issue of result.error.issues) {
-      const key = issue.path.join(".");
-      if (!fieldErrors[key]) fieldErrors[key] = [];
-      fieldErrors[key].push(issue.message);
-    }
-    return { error: "Please fix the errors below.", fieldErrors };
+    return {
+      error: "Please fix the errors below.",
+      fieldErrors: collectFieldErrors(result.error.issues),
+    };
   }
 
   const data = result.data;
@@ -71,4 +78,65 @@ export async function submitNdotStormwater(
 
   revalidatePath(`/dashboard/projects/${projectId}`);
   redirect(`/dashboard/projects/${projectId}?tab=ndot_weekly_stormwater`);
+}
+
+export async function updateNdotStormwater(
+  submissionId: string,
+  _prevState: NdotStormwaterState,
+  formData: FormData,
+): Promise<NdotStormwaterState> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+  if (user.role !== "admin") {
+    return { error: "Admin access required to edit submissions." };
+  }
+
+  const projectId = formData.get("project_id") as string;
+  if (!projectId) {
+    return { error: "Missing project ID." };
+  }
+
+  const raw = parseNdotStormwaterForm(formData);
+  const result = ndotStormwaterSchema.safeParse(raw);
+
+  if (!result.success) {
+    return {
+      error: "Please fix the errors below.",
+      fieldErrors: collectFieldErrors(result.error.issues),
+    };
+  }
+
+  const data = result.data;
+  const supabase = await createClient();
+
+  const { error: updateError } = await supabase
+    .from("form_submissions")
+    .update({
+      data,
+      form_date: data.inspection_date,
+    })
+    .eq("id", submissionId)
+    .eq("project_id", projectId)
+    .eq("form_type", "ndot_weekly_stormwater");
+
+  if (updateError) {
+    return { error: updateError.message };
+  }
+
+  // Replace photo rows so deletes propagate. JSONB stays authoritative.
+  await supabase.from("form_photos").delete().eq("submission_id", submissionId);
+  if (data.photos.length > 0) {
+    const photoRows = data.photos.map((p) => ({
+      submission_id: submissionId,
+      file_path: p.file_name,
+      caption: p.caption || null,
+    }));
+    await supabase.from("form_photos").insert(photoRows);
+  }
+
+  revalidatePath(`/dashboard/projects/${projectId}`);
+  revalidatePath(`/dashboard/projects/${projectId}/forms/ndot-stormwater/${submissionId}`);
+  redirect(`/dashboard/projects/${projectId}/forms/ndot-stormwater/${submissionId}`);
 }

--- a/src/app/dashboard/projects/[id]/forms/nnph-dust-permit/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/nnph-dust-permit/[submissionId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import FormActions from "@/components/form-actions";
+import { getCurrentUser } from "@/lib/auth";
 import { getProjectById, getSubmissionById } from "@/lib/queries/projects";
 import {
   type NnphDustPermitData,
@@ -79,12 +80,15 @@ export default async function NnphDustPermitViewPage({
 }) {
   const { id, submissionId } = await params;
 
-  const [project, submission] = await Promise.all([
+  const [project, submission, user] = await Promise.all([
     getProjectById(id),
     getSubmissionById(submissionId),
+    getCurrentUser(),
   ]);
 
   if (!project || !submission) notFound();
+
+  const canEdit = user?.role === "admin";
 
   const data: NnphDustPermitData | null =
     submission.data && typeof submission.data === "object" && !Array.isArray(submission.data)
@@ -278,7 +282,12 @@ export default async function NnphDustPermitViewPage({
       </section>
 
       {/* Actions */}
-      <FormActions backHref={`/dashboard/projects/${id}?tab=nnph_dust_permit`} submissionId={submissionId} />
+      <FormActions
+        backHref={`/dashboard/projects/${id}?tab=nnph_dust_permit`}
+        submissionId={submissionId}
+        formType="nnph_dust_permit"
+        canEdit={canEdit}
+      />
     </div>
   );
 }

--- a/src/app/dashboard/users/actions.ts
+++ b/src/app/dashboard/users/actions.ts
@@ -17,6 +17,46 @@ async function requireAdmin(): Promise<{ id: string } | UserActionState> {
   return { id: user.id };
 }
 
+// BF-31 RLS treats organization_members.role IN ('owner','admin') as the source of
+// truth for org-admin access. The legacy profiles.role is no longer load-bearing for
+// RLS, so every promote/invite path must keep org_members in sync with profile role.
+function memberRoleFor(profileRole: "admin" | "user"): "admin" | "member" {
+  return profileRole === "admin" ? "admin" : "member";
+}
+
+async function getAdminOrgId(adminId: string): Promise<string | null> {
+  const service = createServiceClient();
+  const { data } = await service
+    .from("organization_members")
+    .select("org_id")
+    .eq("user_id", adminId)
+    .order("joined_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  return data?.org_id ?? null;
+}
+
+async function syncOrgMemberRole(
+  orgId: string,
+  userId: string,
+  profileRole: "admin" | "user",
+  invitedBy?: string,
+): Promise<{ error: string | null }> {
+  const service = createServiceClient();
+  const { error } = await service
+    .from("organization_members")
+    .upsert(
+      {
+        org_id: orgId,
+        user_id: userId,
+        role: memberRoleFor(profileRole),
+        ...(invitedBy ? { invited_by: invitedBy } : {}),
+      },
+      { onConflict: "org_id,user_id" },
+    );
+  return { error: error?.message ?? null };
+}
+
 export async function inviteUser(
   _prevState: UserActionState,
   formData: FormData
@@ -63,18 +103,46 @@ export async function inviteUser(
     return { error: `Failed to invite user: ${createError.message}` };
   }
 
-  // Update role if admin (trigger creates profile with default 'user')
-  if (role === "admin") {
-    // Small delay to let the trigger create the profile
-    await new Promise((r) => setTimeout(r, 500));
+  // Wait for the on_auth_user_created trigger to insert the profile row before we
+  // update role or upsert org_members (the trigger only creates profiles, not memberships).
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Find the new user's id so we can sync org_members. Profile is keyed on email here.
+  const { data: newProfile } = await service
+    .from("profiles")
+    .select("id")
+    .eq("email", email)
+    .single();
+
+  if (role === "admin" && newProfile) {
     const { error: roleError } = await service
       .from("profiles")
       .update({ role: "admin" })
-      .eq("email", email);
+      .eq("id", newProfile.id);
 
     if (roleError) {
       console.error("Role update error:", roleError);
-      // User created but role update failed — not fatal
+      // User created but role update failed — not fatal; org sync below is gated on
+      // the role we already validated, not on the DB read-back.
+    }
+  }
+
+  // Add the invitee to the inviting admin's org with the matching membership role.
+  // Without this, BF-31 RLS denies them every project-scoped query.
+  if (newProfile) {
+    const orgId = await getAdminOrgId(admin.id);
+    if (orgId) {
+      const { error: syncError } = await syncOrgMemberRole(
+        orgId,
+        newProfile.id,
+        role as "admin" | "user",
+        admin.id,
+      );
+      if (syncError) {
+        console.error("Org member sync error:", syncError);
+      }
+    } else {
+      console.error("inviteUser: inviting admin has no org_members row; cannot sync invitee.");
     }
   }
 
@@ -124,6 +192,19 @@ export async function updateRole(
   if (error) {
     console.error("updateRole error:", error);
     return { error: `Failed to update role: ${error.message}` };
+  }
+
+  // Sync organization_members.role so BF-31 RLS sees the new tier. Use the calling
+  // admin's org context — single-org assumption holds until BF-33 ships.
+  const orgId = await getAdminOrgId(admin.id);
+  if (orgId) {
+    const { error: syncError } = await syncOrgMemberRole(orgId, userId, newRole);
+    if (syncError) {
+      console.error("updateRole org_members sync error:", syncError);
+      return { error: `Profile updated but org membership sync failed: ${syncError}` };
+    }
+  } else {
+    console.error("updateRole: calling admin has no org_members row; cannot sync target.");
   }
 
   revalidatePath("/dashboard/users");

--- a/src/components/form-actions.tsx
+++ b/src/components/form-actions.tsx
@@ -1,15 +1,46 @@
 "use client";
 
-import { ArrowLeft, Download } from "lucide-react";
+import { ArrowLeft, Download, Pencil } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+
+type FormType =
+  | "daily_dust_log"
+  | "ndot_weekly_stormwater"
+  | "ndep_weekly_stormwater"
+  | "ndep_sad_application"
+  | "nnph_dust_permit";
 
 interface FormActionsProps {
   backHref: string;
   submissionId: string;
+  /**
+   * Optional: pass the form type + edit href to render an admin-only Edit button.
+   * Forms that haven't been refactored for in-place edit (NDEP-stormwater, NDEP-SAD,
+   * NNPH dust) render the button disabled with a "coming next sprint" tooltip.
+   */
+  formType?: FormType;
+  editHref?: string;
+  canEdit?: boolean;
 }
 
-export default function FormActions({ backHref, submissionId }: FormActionsProps) {
+const EDIT_SUPPORTED: ReadonlySet<FormType> = new Set([
+  // daily_dust_log uses its own "Add Entries" button on the view page (append-only model)
+  "ndot_weekly_stormwater",
+]);
+
+export default function FormActions({
+  backHref,
+  submissionId,
+  formType,
+  editHref,
+  canEdit,
+}: FormActionsProps) {
   const router = useRouter();
+
+  const showEdit =
+    canEdit && formType !== undefined && formType !== "daily_dust_log";
+  const editEnabled = showEdit && EDIT_SUPPORTED.has(formType!) && Boolean(editHref);
 
   return (
     <div className="flex items-center gap-3 border-t border-zinc-200 pt-6 dark:border-zinc-800 print:hidden">
@@ -21,6 +52,27 @@ export default function FormActions({ backHref, submissionId }: FormActionsProps
         <ArrowLeft className="h-4 w-4" />
         Back
       </button>
+
+      {showEdit &&
+        (editEnabled ? (
+          <Link
+            href={editHref!}
+            className="inline-flex items-center gap-2 rounded-md border border-[#5C6F8A] bg-white px-4 py-2 text-sm font-medium text-[#233B5C] shadow-sm hover:bg-[#5C6F8A]/10 dark:border-zinc-500 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+          >
+            <Pencil className="h-4 w-4" />
+            Edit
+          </Link>
+        ) : (
+          <button
+            type="button"
+            disabled
+            title="Edit for this form type is coming next sprint."
+            className="inline-flex cursor-not-allowed items-center gap-2 rounded-md border border-zinc-200 bg-zinc-50 px-4 py-2 text-sm font-medium text-zinc-400 dark:border-zinc-700 dark:bg-zinc-800/40 dark:text-zinc-500"
+          >
+            <Pencil className="h-4 w-4" />
+            Edit
+          </button>
+        ))}
 
       <a
         href={`/api/forms/${submissionId}/pdf`}

--- a/src/components/forms/ndot-stormwater/NdotStormwaterForm.tsx
+++ b/src/components/forms/ndot-stormwater/NdotStormwaterForm.tsx
@@ -3,6 +3,7 @@
 import { useActionState, useState } from "react";
 import {
   submitNdotStormwater,
+  updateNdotStormwater,
   type NdotStormwaterState,
 } from "@/app/dashboard/projects/[id]/forms/ndot-stormwater/actions";
 import {
@@ -22,6 +23,11 @@ interface NdotStormwaterFormProps {
   contractNumber: string;
   location: string;
   previousData?: NdotStormwaterData | null;
+  /** When set, the form runs in edit mode against this submission. */
+  submissionId?: string;
+  /** Pre-populated data for edit mode. Required when submissionId is set. */
+  initialData?: NdotStormwaterData;
+  cancelHref?: string;
 }
 
 function makeDefaultBmpCategories(): BmpCategory[] {
@@ -98,10 +104,17 @@ export default function NdotStormwaterForm({
   contractNumber,
   location,
   previousData,
+  submissionId,
+  initialData,
+  cancelHref,
 }: NdotStormwaterFormProps) {
-  const [state, formAction, pending] = useActionState(submitNdotStormwater, initialState);
+  const isEdit = Boolean(submissionId);
+  const action = isEdit
+    ? updateNdotStormwater.bind(null, submissionId as string)
+    : submitNdotStormwater;
+  const [state, formAction, pending] = useActionState(action, initialState);
   const [data, setData] = useState<NdotStormwaterData>(() =>
-    makeEmptyData(projectName, contractNumber, location)
+    initialData ?? makeEmptyData(projectName, contractNumber, location)
   );
   const [usedPrevious, setUsedPrevious] = useState(false);
 
@@ -141,9 +154,11 @@ export default function NdotStormwaterForm({
 
       <div className="flex items-center justify-between">
         <p className="text-sm text-zinc-500 dark:text-zinc-400">
-          Weekly stormwater inspection checklist per NDOT requirements.
+          {isEdit
+            ? "Editing existing inspection. Changes save against the original submission."
+            : "Weekly stormwater inspection checklist per NDOT requirements."}
         </p>
-        {previousData && !usedPrevious && (
+        {!isEdit && previousData && !usedPrevious && (
           <button
             type="button"
             onClick={applyPrevious}
@@ -152,7 +167,7 @@ export default function NdotStormwaterForm({
             Use Previous
           </button>
         )}
-        {usedPrevious && (
+        {!isEdit && usedPrevious && (
           <span className="text-xs text-green-600 dark:text-green-400">
             Pre-filled from last submission (date/signatures cleared)
           </span>
@@ -171,12 +186,22 @@ export default function NdotStormwaterForm({
       <Section3DischargeSignatures data={data} onChange={update} fieldErrors={state.fieldErrors} />
 
       <div className="flex items-center gap-4 border-t border-zinc-200 pt-6 dark:border-zinc-800">
+        {cancelHref && (
+          <a
+            href={cancelHref}
+            className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 shadow-sm hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+          >
+            Cancel
+          </a>
+        )}
         <button
           type="submit"
           disabled={pending}
           className="rounded-md bg-[#233B5C] px-6 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#1a2d47] focus:outline-none focus:ring-2 focus:ring-[#5C6F8A] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {pending ? "Submitting..." : "Submit Inspection"}
+          {pending
+            ? isEdit ? "Saving..." : "Submitting..."
+            : isEdit ? "Save Changes" : "Submit Inspection"}
         </button>
       </div>
     </form>

--- a/src/components/projects/ProjectTabs.tsx
+++ b/src/components/projects/ProjectTabs.tsx
@@ -5,6 +5,8 @@ import { usePathname } from "next/navigation";
 import { PERMIT_LABELS, FORM_LABELS, type FormType, type PermitType } from "@/lib/constants/permits";
 import DocumentsTab from "./DocumentsTab";
 
+const WATERWAY_PLACEHOLDER_KEY = "waterway_placeholder";
+
 interface Permit {
   id: string;
   permit_type: string;
@@ -68,7 +70,15 @@ export default function ProjectTabs({
     label: FORM_LABELS[fr.form_type as FormType] ?? fr.form_type,
   }));
 
-  const allTabs = [staticTabs[0], ...formTabs, staticTabs[1], staticTabs[2]];
+  // BF-41: when the project has a Waterway permit, render a placeholder tab so it
+  // doesn't look like the permit is unacknowledged. The actual form is queued for a
+  // future sprint — no FORM_TYPES / PERMIT_FORM_MAP entry yet, so we inject a sentinel.
+  const hasWaterwayPermit = permits.some((p) => p.permit_type === "waterway");
+  const waterwayTabs = hasWaterwayPermit
+    ? [{ key: WATERWAY_PLACEHOLDER_KEY, label: "Work in Waterway" }]
+    : [];
+
+  const allTabs = [staticTabs[0], ...formTabs, ...waterwayTabs, staticTabs[1], staticTabs[2]];
 
   return (
     <div>
@@ -102,6 +112,9 @@ export default function ProjectTabs({
         )}
         {activeTab === "team" && (
           <Placeholder message="Team management coming soon." />
+        )}
+        {activeTab === WATERWAY_PLACEHOLDER_KEY && (
+          <Placeholder message="The Work in Waterway form is queued for the next sprint." />
         )}
         {formTabs.some((ft) => ft.key === activeTab) && (
           <FormTabContent

--- a/supabase/migrations/20260504120000_fix_storage_rls_qualifier.sql
+++ b/supabase/migrations/20260504120000_fix_storage_rls_qualifier.sql
@@ -1,0 +1,107 @@
+-- BF-32 (reopened) — Storage RLS column-qualifier fix (UAT round 3, 2026-05-04)
+--
+-- Root cause: the policies from 20260424140000_private_storage.sql nested
+-- `EXISTS (SELECT 1 FROM projects p WHERE p.id = ((storage.foldername(name))[2])::uuid ...)`.
+-- Postgres resolved the unqualified `name` to `p.name` (project display name) instead of
+-- `storage.objects.name` (path). Project names contain no '/', so storage.foldername
+-- returned [], [2] returned NULL, EXISTS never matched. Only is_super_admin() succeeded.
+--
+-- Fix shape: extract the path-derived project id at the OUTER scope, then check membership
+-- via a flat IN-subquery. `name` only appears at the storage.objects level, so the
+-- alias-collision class of bug is structurally impossible.
+
+DROP POLICY IF EXISTS form_attachments_read   ON storage.objects;
+DROP POLICY IF EXISTS form_attachments_upload ON storage.objects;
+DROP POLICY IF EXISTS form_attachments_delete ON storage.objects;
+DROP POLICY IF EXISTS project_documents_read   ON storage.objects;
+DROP POLICY IF EXISTS project_documents_upload ON storage.objects;
+DROP POLICY IF EXISTS project_documents_delete ON storage.objects;
+
+-- form-attachments: photo uploads from the form components (PhotoAttachment.tsx).
+-- Path layout: projects/{project_id}/{form_type}/{filename}.
+-- Read + upload allow org-admins and project-members; delete allows org-admins only.
+
+CREATE POLICY form_attachments_read ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'form-attachments'
+    AND (
+      (SELECT public.is_super_admin())
+      OR ((storage.foldername(name))[2])::uuid IN (
+        SELECT p.id FROM public.projects p
+        WHERE public.is_org_admin(p.organization_id)
+           OR p.id = ANY(public.get_user_project_ids())
+      )
+    )
+  );
+
+CREATE POLICY form_attachments_upload ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'form-attachments'
+    AND (
+      (SELECT public.is_super_admin())
+      OR ((storage.foldername(name))[2])::uuid IN (
+        SELECT p.id FROM public.projects p
+        WHERE public.is_org_admin(p.organization_id)
+           OR p.id = ANY(public.get_user_project_ids())
+      )
+    )
+  );
+
+CREATE POLICY form_attachments_delete ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'form-attachments'
+    AND (
+      (SELECT public.is_super_admin())
+      OR ((storage.foldername(name))[2])::uuid IN (
+        SELECT p.id FROM public.projects p
+        WHERE public.is_org_admin(p.organization_id)
+      )
+    )
+  );
+
+-- project-documents: admin doc uploads from the project Documents tab.
+-- Path layout: projects/{project_id}/{filename}.
+-- Read allows org-admins and project-members; upload + delete allow org-admins only.
+
+CREATE POLICY project_documents_read ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'project-documents'
+    AND (
+      (SELECT public.is_super_admin())
+      OR ((storage.foldername(name))[2])::uuid IN (
+        SELECT p.id FROM public.projects p
+        WHERE public.is_org_admin(p.organization_id)
+           OR p.id = ANY(public.get_user_project_ids())
+      )
+    )
+  );
+
+CREATE POLICY project_documents_upload ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'project-documents'
+    AND (
+      (SELECT public.is_super_admin())
+      OR ((storage.foldername(name))[2])::uuid IN (
+        SELECT p.id FROM public.projects p
+        WHERE public.is_org_admin(p.organization_id)
+      )
+    )
+  );
+
+CREATE POLICY project_documents_delete ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'project-documents'
+    AND (
+      (SELECT public.is_super_admin())
+      OR ((storage.foldername(name))[2])::uuid IN (
+        SELECT p.id FROM public.projects p
+        WHERE public.is_org_admin(p.organization_id)
+      )
+    )
+  );


### PR DESCRIPTION
Closes the regressions Andy surfaced in his 2026-05-04 UAT of BF-31 + BF-32.

## Storage RLS regression — root cause

BF-32 Step 3b shipped 6 storage policies that nested `storage.foldername(name)` inside `EXISTS (SELECT 1 FROM projects p WHERE ...)`. Postgres bound the unqualified `name` to `p.name` (project display name like "Q&D Parking Lot"), not `storage.objects.name` (the path). Project names contain no `/`, so `storage.foldername` returned `[]`, the `EXISTS` branch never matched, and only the `is_super_admin()` short-circuit succeeded — Tim was the only user who could upload or download.

Verified live before fix:

```text
storage.foldername("US-95 Widening Phase 2") -> []
[2] of [] -> NULL
NULL::uuid -> NULL  =>  EXISTS branch always false
```

This was already applied direct to prod via Supabase MCP earlier today (`apply_migration` name=`fix_storage_rls_qualifier`). The migration file in this PR is the canonical record of what's live; Vercel auto-deploy of the merged code lights up the application-side pieces.

## What's in this PR

| Commit | Concern | SP |
|---|---|---|
| 67dc48f | BF-32 reopen — storage RLS column-qualifier fix | — |
| d05c703 | BF-38 — sync org_members.role on invite + role change | 1 |
| 2577e38 | BF-39 — admin Edit button + NDOT edit page | 2 |
| 51dcc54 | BF-41 — Waterway "coming soon" placeholder tab | 0.5 |

### BF-32 reopen — storage RLS qualifier fix
Pull path-extraction OUT of the `EXISTS` subquery so `name` only appears at the `storage.objects` scope. Now uses `((storage.foldername(name))[2])::uuid IN (SELECT p.id FROM projects p WHERE ...)` — alias-collision class of bug is structurally impossible.

### BF-38 — user-management org_members.role sync
After BF-31 the legacy `profiles.role` no longer drives RLS. The /dashboard/users invite + Make Admin flows only updated `profiles.role`, leaving new admins as plain members at the RLS layer (Andy's A2 finding with `itadmin@pleniumbuilders.com`).

- `inviteUser` upserts an `organization_members` row in the inviting admin's org with the matching membership role after the `on_auth_user_created` trigger lands the profile.
- `updateRole` upserts the target user's `org_members` row alongside the profile change.
- One-shot backfill applied to prod via Supabase MCP — itadmin lifted to admin so Andy's A2 retest is unblocked.

### BF-39 — admin Edit button + NDOT edit page
Andy's A4.3 flagged that submissions had no Edit option.

- `form-actions.tsx` renders an admin-only Edit button. Enabled for ndot_weekly_stormwater. Disabled with "coming next sprint" tooltip on ndep_weekly_stormwater, ndep_sad_application, nnph_dust_permit. Hidden for daily_dust_log (its view page already has Add Entries) and non-admin users.
- New `ndot-stormwater/[submissionId]/edit/page.tsx` — admin-gated, fetches existing submission, hands `initialData` + `submissionId` to the form.
- `updateNdotStormwater` server action — admin-gated, validates via the same Zod schema as submit, replaces `form_photos` rows, redirects back to view.
- `NdotStormwaterForm` now branches on edit mode: binds to update action, hides "Use Previous", swaps copy ("Save Changes" vs "Submit Inspection"), shows Cancel link.

Edit pages for the remaining 3 form types deferred to Sprint 4.

### BF-41 — Waterway placeholder
Andy expected a tab when he added the Waterway permit. PERMIT_FORM_MAP has `waterway -> []` because the form is not yet built. Inject a placeholder tab via a sentinel key (`waterway_placeholder`) when the project has any waterway permit. Tab body shows "queued for the next sprint."

Pure UI — no FormType, no DB constraint changes, no PERMIT_FORM_MAP entry.

## Andy's UAT findings — disposition

| Test | Disposition |
|---|---|
| BF-31 A1.4 (Andy admin sees 6 projects) | ✓ already passing |
| BF-31 A2 (itadmin@pleniumbuilders.com sees 0 forms) | Fixed by BF-38 backfill + sync |
| BF-31 A3 (standard user no Forms tab) | ✓ working as designed |
| BF-31 A4.3 (no Edit option) | Fixed by BF-39 (NDOT only this round; tooltip on others) |
| BF-32 Test 1 (no NDOT photos to view) | Test data gap, not a bug. Andy can upload now. |
| BF-32 Test 2 (download greyed out) | Fixed by BF-32 RLS — was downstream of failing signed-URL |
| BF-32 Test 3 (doc upload RLS fail) | Fixed by BF-32 RLS |
| BF-32 Test 4 (photo upload RLS fail) | Fixed by BF-32 RLS |
| BF-32 Test 5 (Edge inspector view) | Investigation deferred — workaround is download. Filed BF-40. |
| BF-32 Test 6 (PDF works, no NDOT photos) | ✓ pending photo data |
| BF-32 Test 7 (pre-flip URL test) | Untestable, no historical URLs |
| BF-32 Test 8 SAD missing | No bug — labeled "NDEP SAD Application" in DB, Andy missed the label. Verified all his projects have form_type populated. |
| BF-32 Test 8 Waterway missing | Fixed by BF-41 placeholder tab |
| Gracie still can't log in | Out of scope, separate auth issue |

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm build` — clean, 32 routes, NDOT edit registered
- [x] Storage RLS migration applied live to prod via Supabase MCP, verified via `pg_policies` reshape and impersonation predicate test (Andy + super_admin both → true)
- [x] org_members backfill applied; itadmin row lifted to admin
- [ ] Andy retests BF-32 Tests 2/3/4 in browser — uploads succeed, downloads ungrey
- [ ] Andy retests BF-31 A2 logged in as itadmin — sees Q&D submissions
- [ ] Andy clicks Edit on an NDOT submission, makes a change, saves, verifies persistence
- [ ] Andy adds a Waterway permit and confirms the placeholder tab renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)