### PR TITLE
feat(rls): BF-42 org-scoped visibility + BF-43 edit ownership (2 SP)

### DIFF
--- a/docs/sprints/sprint-3/stories/BF-42-org-scoped-visibility.md
+++ b/docs/sprints/sprint-3/stories/BF-42-org-scoped-visibility.md
@@ -1,0 +1,95 @@
+# BF-42: Org-Scoped Visibility for All Members
+
+**Type:** Architecture / RLS model change
+**Priority:** HIGH (UAT round 3 — A3 unblock)
+**Points:** 1
+**Status:** DONE — migration LIVE in prod 2026-05-04 via Supabase MCP, Andy confirmed working as desired
+**Sprint:** 3
+**Depends on:** BF-31 (multi-tenant RLS), BF-32 (storage privatization)
+**Reported by:** Andy Breen, UAT round 3 meeting 2026-05-04
+
+## Problem
+
+Andy raised two points during the 2026-05-04 UAT meeting that converged on the same answer:
+
+1. The general-user (`role: user`) `abreen@qdgroupinvesco.com` saw zero projects and zero forms, because `project_users` had no rows for them. Andy could not assign them through the UI — the Team tab is a "coming soon" placeholder.
+2. Andy stated that in construction, workers regularly move between jobs and crews. Per-project access control is more friction than it is worth — the org-trust boundary is the right one, not the project-trust boundary.
+
+The pre-BF-42 RLS predicate for non-admin users was:
+
+```
+is_super_admin() OR is_org_admin(<org_id>) OR project_id = ANY(get_user_project_ids())
+```
+
+`get_user_project_ids()` reads `project_users` joined with `projects` filtered to the user's orgs. With no `project_users` rows for a user, the third branch is empty and only super_admin / org_admin succeed — general users see nothing.
+
+## Decision
+
+**Drop project-level access control entirely. Org membership is the read/write boundary.**
+
+- Any member of the org sees all projects, permits, form requirements, submissions, photos, and documents in their org.
+- Any member of the org may submit forms / upload photos for any project in their org.
+- Admin-only writes (create/edit/delete project, edit/delete permits, edit/delete form_requirements, delete documents) keep their `is_org_admin` gate — unchanged.
+- `project_users` table is left in place but is no longer load-bearing for access. Future cleanup may drop it or repurpose it for project-role metadata (foreman, super, etc.).
+- `get_user_project_ids()` function is left in place but no longer referenced by any RLS policy. Safe to drop in a follow-up.
+
+## RLS pattern (canonical)
+
+```sql
+project_id IN (
+  SELECT p.id FROM public.projects p
+  WHERE p.organization_id = ANY(public.current_org_ids())
+)
+```
+
+This shape is structurally immune to the BF-32 alias-collision bug class — the outer table's `project_id` column never appears inside the subquery scope.
+
+## Changes
+
+**Migration:** `supabase/migrations/20260504160000_org_scoped_visibility.sql`
+
+13 policies replaced:
+
+| Schema | Table | Policies replaced |
+|---|---|---|
+| public | form_submissions | submissions_select, submissions_insert, submissions_update |
+| public | form_photos | photos_select, photos_insert |
+| public | project_documents | project_documents_select, project_documents_insert |
+| public | project_form_requirements | form_requirements_select |
+| public | project_permits | permits_select |
+| public | qr_tokens | qr_tokens_all (single ALL policy with both qual + with_check) |
+| storage | objects | form_attachments_read, form_attachments_upload, project_documents_read |
+
+DELETE policies on `project_documents`, `project_permits`, `project_form_requirements`, and storage `*_delete` are unchanged — admin-only.
+
+`projects_select` was already org-scoped via `current_org_ids()` (no change needed).
+
+## Apply path
+
+Direct to prod via Supabase MCP `apply_migration name=org_scoped_visibility` — same path as BF-31 Option A and BF-32 Step 3b. Supabase handles the rollback (ad-hoc DDL is reversible by re-applying the prior policy bodies if needed; Tim has the BF-31 + BF-32 backups locally).
+
+## Verification
+
+Pre-fix predicate count for `abreen@qdgroupinvesco.com` (general user, member-only): 0 projects / 0 submissions.
+
+Post-fix predicate count under the same user (predicate-simulated via `current_org_ids()`):
+
+| Resource | Visible |
+|---|---|
+| Projects | 7 |
+| Form submissions | 15 |
+| Permits | 23 |
+| Form requirements | 25 |
+| Documents | 2 |
+
+Andy confirmed during the meeting: "works correctly now, as desired."
+
+## Out of scope
+
+- UI to manage `project_users` membership (the original "Team tab" feature) — no longer needed for access control. If we ever surface project-role metadata, that's a separate story.
+- Multi-org user routing — still BF-33's territory.
+- Cleanup pass dropping `project_users` and `get_user_project_ids()` — defer until BF-33 lands and we're confident nothing else depends on them.
+
+## Notes
+
+This decision is logged in `direction-log.md` under 2026-05-04 because it changes the RLS contract. Anyone reading the BF-31 / BF-32 stories should follow the link forward to BF-42 to see the current model.

--- a/src/app/dashboard/projects/[id]/forms/ndep-sad/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/ndep-sad/[submissionId]/page.tsx
@@ -73,7 +73,7 @@ export default async function NdepSadViewPage({
 
   if (!project || !submission) notFound();
 
-  const canEdit = user?.role === "admin";
+  const canEdit = user?.role === "admin" || (!!user && user.id === submission.submitted_by);
 
   const data: NdepSadData | null =
     submission.data && typeof submission.data === "object" && !Array.isArray(submission.data)

--- a/src/app/dashboard/projects/[id]/forms/ndep-stormwater/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/ndep-stormwater/[submissionId]/page.tsx
@@ -46,7 +46,7 @@ export default async function NdepStormwaterViewPage({
 
   if (!project || !submission) notFound();
 
-  const canEdit = user?.role === "admin";
+  const canEdit = user?.role === "admin" || (!!user && user.id === submission.submitted_by);
 
   const ndepPermit = project.project_permits?.find(
     (p: { permit_type: string; permit_number: string | null }) =>

--- a/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/edit/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/edit/page.tsx
@@ -13,15 +13,17 @@ export default async function EditNdotStormwaterPage({
 
   const user = await getCurrentUser();
   if (!user) redirect("/login");
-  if (user.role !== "admin") {
-    redirect(`/dashboard/projects/${id}/forms/ndot-stormwater/${submissionId}`);
-  }
 
   const [project, submission] = await Promise.all([
     getProjectById(id),
     getSubmissionById(submissionId),
   ]);
   if (!project || !submission) notFound();
+
+  const canEdit = user.role === "admin" || user.id === submission.submitted_by;
+  if (!canEdit) {
+    redirect(`/dashboard/projects/${id}/forms/ndot-stormwater/${submissionId}`);
+  }
 
   const ndotPermit = project.project_permits?.find(
     (p: { permit_type: string; permit_number: string | null }) =>

--- a/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/page.tsx
@@ -55,7 +55,7 @@ export default async function NdotStormwaterViewPage({
 
   if (!project || !submission) notFound();
 
-  const canEdit = user?.role === "admin";
+  const canEdit = user?.role === "admin" || (!!user && user.id === submission.submitted_by);
 
   const ndotPermit = project.project_permits?.find(
     (p: { permit_type: string; permit_number: string | null }) =>

--- a/src/app/dashboard/projects/[id]/forms/ndot-stormwater/actions.ts
+++ b/src/app/dashboard/projects/[id]/forms/ndot-stormwater/actions.ts
@@ -89,13 +89,25 @@ export async function updateNdotStormwater(
   if (!user) {
     return { error: "You must be logged in." };
   }
-  if (user.role !== "admin") {
-    return { error: "Admin access required to edit submissions." };
-  }
 
   const projectId = formData.get("project_id") as string;
   if (!projectId) {
     return { error: "Missing project ID." };
+  }
+
+  const supabasePre = await createClient();
+  const { data: existing } = await supabasePre
+    .from("form_submissions")
+    .select("submitted_by")
+    .eq("id", submissionId)
+    .maybeSingle();
+
+  if (!existing) {
+    return { error: "Submission not found." };
+  }
+
+  if (user.role !== "admin" && existing.submitted_by !== user.id) {
+    return { error: "You can only edit submissions you created." };
   }
 
   const raw = parseNdotStormwaterForm(formData);
@@ -109,7 +121,7 @@ export async function updateNdotStormwater(
   }
 
   const data = result.data;
-  const supabase = await createClient();
+  const supabase = supabasePre;
 
   const { error: updateError } = await supabase
     .from("form_submissions")

--- a/src/app/dashboard/projects/[id]/forms/nnph-dust-permit/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/nnph-dust-permit/[submissionId]/page.tsx
@@ -88,7 +88,7 @@ export default async function NnphDustPermitViewPage({
 
   if (!project || !submission) notFound();
 
-  const canEdit = user?.role === "admin";
+  const canEdit = user?.role === "admin" || (!!user && user.id === submission.submitted_by);
 
   const data: NnphDustPermitData | null =
     submission.data && typeof submission.data === "object" && !Array.isArray(submission.data)

--- a/supabase/migrations/20260504160000_org_scoped_visibility.sql
+++ b/supabase/migrations/20260504160000_org_scoped_visibility.sql
@@ -1,0 +1,209 @@
+-- BF-42 — Org-scoped visibility for all members
+--
+-- Construction users move project-to-project; per-project access control adds
+-- friction without security benefit. This migration drops the
+-- project_users / get_user_project_ids() gate and replaces it with org
+-- membership: any member of the org sees all org content (projects, permits,
+-- form requirements, submissions, photos, documents, qr tokens, storage).
+-- Admin-only writes (create/edit/delete projects, permits, form_requirements,
+-- project_documents) keep their is_org_admin gate — unchanged.
+--
+-- Pattern used everywhere:
+--   project_id IN (SELECT p.id FROM projects p WHERE p.organization_id = ANY(current_org_ids()))
+-- This avoids the BF-32 alias-collision class of bug by keeping the outer
+-- table's column outside any inner subquery.
+--
+-- get_user_project_ids() is left in place but no longer referenced by any
+-- policy; safe to drop in a follow-up after monitoring.
+
+-- ============================================================================
+-- public.form_submissions
+-- ============================================================================
+DROP POLICY IF EXISTS submissions_select ON public.form_submissions;
+DROP POLICY IF EXISTS submissions_insert ON public.form_submissions;
+DROP POLICY IF EXISTS submissions_update ON public.form_submissions;
+
+CREATE POLICY submissions_select ON public.form_submissions
+  FOR SELECT TO authenticated
+  USING (
+    (SELECT public.is_super_admin())
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+CREATE POLICY submissions_insert ON public.form_submissions
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT public.is_super_admin())
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+CREATE POLICY submissions_update ON public.form_submissions
+  FOR UPDATE TO authenticated
+  USING (
+    (SELECT public.is_super_admin())
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+-- ============================================================================
+-- public.form_photos
+-- ============================================================================
+DROP POLICY IF EXISTS photos_select ON public.form_photos;
+DROP POLICY IF EXISTS photos_insert ON public.form_photos;
+
+CREATE POLICY photos_select ON public.form_photos
+  FOR SELECT TO authenticated
+  USING (
+    (SELECT public.is_super_admin())
+    OR submission_id IN (
+      SELECT fs.id FROM public.form_submissions fs
+      JOIN public.projects p ON p.id = fs.project_id
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+CREATE POLICY photos_insert ON public.form_photos
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT public.is_super_admin())
+    OR submission_id IN (
+      SELECT fs.id FROM public.form_submissions fs
+      JOIN public.projects p ON p.id = fs.project_id
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+-- ============================================================================
+-- public.project_documents
+-- ============================================================================
+DROP POLICY IF EXISTS project_documents_select ON public.project_documents;
+DROP POLICY IF EXISTS project_documents_insert ON public.project_documents;
+
+CREATE POLICY project_documents_select ON public.project_documents
+  FOR SELECT TO authenticated
+  USING (
+    (SELECT public.is_super_admin())
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+CREATE POLICY project_documents_insert ON public.project_documents
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT public.is_super_admin())
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+-- project_documents_delete stays admin-only (untouched).
+
+-- ============================================================================
+-- public.project_form_requirements (only SELECT changes)
+-- ============================================================================
+DROP POLICY IF EXISTS form_requirements_select ON public.project_form_requirements;
+
+CREATE POLICY form_requirements_select ON public.project_form_requirements
+  FOR SELECT TO authenticated
+  USING (
+    (SELECT public.is_super_admin())
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+-- ============================================================================
+-- public.project_permits (only SELECT changes)
+-- ============================================================================
+DROP POLICY IF EXISTS permits_select ON public.project_permits;
+
+CREATE POLICY permits_select ON public.project_permits
+  FOR SELECT TO authenticated
+  USING (
+    (SELECT public.is_super_admin())
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+-- ============================================================================
+-- public.qr_tokens (single ALL policy with both qual + with_check)
+-- ============================================================================
+DROP POLICY IF EXISTS qr_tokens_all ON public.qr_tokens;
+
+CREATE POLICY qr_tokens_all ON public.qr_tokens
+  FOR ALL TO authenticated
+  USING (
+    (SELECT public.is_super_admin())
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  )
+  WITH CHECK (
+    (SELECT public.is_super_admin())
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE p.organization_id = ANY(public.current_org_ids())
+    )
+  );
+
+-- ============================================================================
+-- storage.objects — form-attachments + project-documents (read/upload only;
+--   delete policies are admin-only and untouched here)
+-- ============================================================================
+DROP POLICY IF EXISTS form_attachments_read ON storage.objects;
+DROP POLICY IF EXISTS form_attachments_upload ON storage.objects;
+DROP POLICY IF EXISTS project_documents_read ON storage.objects;
+
+CREATE POLICY form_attachments_read ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'form-attachments'
+    AND (
+      (SELECT public.is_super_admin())
+      OR ((storage.foldername(name))[2])::uuid IN (
+        SELECT p.id FROM public.projects p
+        WHERE p.organization_id = ANY(public.current_org_ids())
+      )
+    )
+  );
+
+CREATE POLICY form_attachments_upload ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'form-attachments'
+    AND (
+      (SELECT public.is_super_admin())
+      OR ((storage.foldername(name))[2])::uuid IN (
+        SELECT p.id FROM public.projects p
+        WHERE p.organization_id = ANY(public.current_org_ids())
+      )
+    )
+  );
+
+CREATE POLICY project_documents_read ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'project-documents'
+    AND (
+      (SELECT public.is_super_admin())
+      OR ((storage.foldername(name))[2])::uuid IN (
+        SELECT p.id FROM public.projects p
+        WHERE p.organization_id = ANY(public.current_org_ids())
+      )
+    )
+  );

--- a/supabase/migrations/20260504170000_submission_edit_ownership.sql
+++ b/supabase/migrations/20260504170000_submission_edit_ownership.sql
@@ -1,0 +1,86 @@
+-- BF-43 — Submission edit ownership
+--
+-- Rule (per Andy 2026-05-04 in-meeting): general users may edit ONLY their own
+-- submissions. Org admins continue to edit any submission in their org.
+-- super_admin unchanged.
+--
+-- Changes:
+--   • form_submissions.submissions_update — tightened from "any org member" to
+--     "owner OR org_admin OR super_admin"
+--   • form_photos.photos_insert — same tightening (photo writes track submission writes)
+--   • form_photos.photos_delete — NEW policy. updateNdotStormwater action does
+--     DELETE-then-INSERT on form_photos; without a DELETE policy, edits failed
+--     silently for non-superuser.
+--
+-- read paths (submissions_select, photos_select) remain org-scoped — any
+-- org member may read all org content, unchanged from BF-42.
+
+-- ============================================================================
+-- form_submissions.submissions_update
+-- ============================================================================
+DROP POLICY IF EXISTS submissions_update ON public.form_submissions;
+
+CREATE POLICY submissions_update ON public.form_submissions
+  FOR UPDATE TO authenticated
+  USING (
+    (SELECT public.is_super_admin())
+    OR (
+      submitted_by = auth.uid()
+      AND project_id IN (
+        SELECT p.id FROM public.projects p
+        WHERE p.organization_id = ANY(public.current_org_ids())
+      )
+    )
+    OR project_id IN (
+      SELECT p.id FROM public.projects p
+      WHERE public.is_org_admin(p.organization_id)
+    )
+  );
+
+-- ============================================================================
+-- form_photos.photos_insert
+-- ============================================================================
+DROP POLICY IF EXISTS photos_insert ON public.form_photos;
+
+CREATE POLICY photos_insert ON public.form_photos
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT public.is_super_admin())
+    OR submission_id IN (
+      SELECT fs.id FROM public.form_submissions fs
+      WHERE fs.submitted_by = auth.uid()
+        AND fs.project_id IN (
+          SELECT p.id FROM public.projects p
+          WHERE p.organization_id = ANY(public.current_org_ids())
+        )
+    )
+    OR submission_id IN (
+      SELECT fs.id FROM public.form_submissions fs
+      JOIN public.projects p ON p.id = fs.project_id
+      WHERE public.is_org_admin(p.organization_id)
+    )
+  );
+
+-- ============================================================================
+-- form_photos.photos_delete (NEW)
+-- ============================================================================
+DROP POLICY IF EXISTS photos_delete ON public.form_photos;
+
+CREATE POLICY photos_delete ON public.form_photos
+  FOR DELETE TO authenticated
+  USING (
+    (SELECT public.is_super_admin())
+    OR submission_id IN (
+      SELECT fs.id FROM public.form_submissions fs
+      WHERE fs.submitted_by = auth.uid()
+        AND fs.project_id IN (
+          SELECT p.id FROM public.projects p
+          WHERE p.organization_id = ANY(public.current_org_ids())
+        )
+    )
+    OR submission_id IN (
+      SELECT fs.id FROM public.form_submissions fs
+      JOIN public.projects p ON p.id = fs.project_id
+      WHERE public.is_org_admin(p.organization_id)
+    )
+  );


### PR DESCRIPTION
## Summary

UAT round 3 meeting follow-ups — both migrations already LIVE in prod via Supabase MCP; this PR ships the application-side gates.

### BF-42 — Org-scoped visibility (1 SP)
- Dropped per-project access control. Any org member sees all projects/forms/photos/docs in their org and can submit forms anywhere in the org.
- 13 RLS policies rewritten across `form_submissions`, `form_photos`, `project_documents`, `project_form_requirements`, `project_permits`, `qr_tokens`, and `storage.objects`.
- Admin-only writes (create/delete project, edit/delete permits + form_requirements, delete documents) keep `is_org_admin` gate, unchanged.
- Andy: "works correctly now, as desired."

### BF-43 — Submission edit ownership (1 SP)
- General users may edit ONLY their own submissions. Admins still edit any submission in their org.
- `submissions_update` RLS tightened: super_admin OR (owner AND in org) OR org_admin.
- `photos_insert` RLS tightened to match.
- `photos_delete` RLS added (NEW) — `updateNdotStormwater` does DELETE-then-INSERT on `form_photos`; without a DELETE policy, edits silently failed for non-superuser.
- 4 view pages: `canEdit = admin || own`.
- NDOT edit page + `updateNdotStormwater` action: drop hard admin gate, allow ownership.

## Test plan
- [ ] Andy (admin) edits an NDOT submission he created → save succeeds
- [ ] Andy (admin) edits an NDOT submission someone else created → save succeeds (admin override)
- [ ] abreen@qdgroupinvesco.com (general user) sees Edit on their own submissions → save succeeds
- [ ] abreen@qdgroupinvesco.com (general user) does NOT see Edit on submissions someone else created
- [ ] Photo upload + delete during edit works for both roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)