### PR TITLE
fix(projects): BF-33 Slice 1 — unblock new-org admin create-project (P0)

### DIFF
--- a/docs/sprints/sprint-3/stories/BF-33-org-switcher-invite-admin.md
+++ b/docs/sprints/sprint-3/stories/BF-33-org-switcher-invite-admin.md
@@ -1,20 +1,23 @@
 # BF-33: Org Switcher, Invite Flow, Super-Admin Routes
 
 **Type:** Feature / UX
-**Priority:** HIGH
-**Points:** 5
-**Status:** NOT STARTED
+**Priority:** HIGH (carries a P0 sub-path — new-org admin create-project, folded from BF-46)
+**Points:** 8 (5 + 3 folded from BF-46; the two stories' provisioning scope overlaps, so it may land under 8)
+**Status:** IN PROGRESS — Slice 1 (P0 create-project unblock, folded BF-46) COMPLETE & MERGED to master (PR #31; Andy UAT ✓ 2026-06-09). Slices 2–5 NOT STARTED.
 **Sprint:** 3
 **Depends on:** BF-31
+**Last Updated:** 2026-06-09T17:44:29Z
+**Folds in:** BF-46 (P0 new-tenant create-project flash) — superseded 2026-06-08; see "Create-Project Path for New-Org Admins" below.
 
 ## Problem
 
 The schema and RLS support multi-tenant, but the app has no UI to actually use it. Need:
 - Active-org context (which org is the user currently viewing).
 - A switcher UI for users in >1 org.
-- Invite flow that scopes to an org (today it just creates a global auth user).
+- Invite flow that scopes to a *chosen* org. Today `inviteUser` already promotes `profiles.role` and syncs `organization_members` into the *inviting admin's first* org (BF-38, `dashboard/users/actions.ts:117-147`) — but it can't target a chosen org, and there is no org-minting path at all.
 - Super-admin route group for Tim/Andy to provision prospect orgs (read-only elsewhere).
 - Route guards for all of the above.
+- **Provision a new org's first admin so they can actually create projects (P0, folded from BF-46).** Today provisioning leaves the admin with `profiles.role='user'`, which the create-project path blocks *before the form renders* — "the screen just flashes."
 
 All user-visible changes must gate behind a feature flag so we can instantly revert UX to single-tenant if anything misbehaves in production.
 
@@ -47,7 +50,7 @@ Flag readers:
 
 - `src/app/admin/layout.tsx` — guards `platform_role='super_admin'`, else redirect to `/dashboard`. Renders a "Support view" banner so it's never confused with dashboard.
 - `src/app/admin/organizations/page.tsx` — list all orgs (super_admin only).
-- `src/app/admin/organizations/new/page.tsx` + `actions.ts` — create org form. Takes name + owner email. If email matches existing user, add as owner immediately. If new email, create `organization_invitations` + `auth.admin.inviteUserByEmail` with `redirectTo=/invite/{token}`.
+- `src/app/admin/organizations/new/page.tsx` + `actions.ts` — create org form. Takes name + owner email. If email matches existing user, add as owner immediately **and set `profiles.role='admin'`** (else the owner can't create projects — see BF-46 fold). If new email, create `organization_invitations` + `auth.admin.inviteUserByEmail` with `redirectTo=/invite/{token}`.
 - `src/app/admin/organizations/[id]/page.tsx` — org detail: members list, audit log view, invite button.
 
 Super-admin reads (all in `/admin/*`) go through `createServiceClient()` (BF-34 adds the audited wrapper).
@@ -58,10 +61,12 @@ Super-admin reads (all in `/admin/*`) go through `createServiceClient()` (BF-34 
   1. Requires `requireOrgAdmin(activeOrgId)`.
   2. Inserts `organization_invitations` row (token = `gen_random_uuid()`, 14-day expires_at).
   3. Calls `auth.admin.inviteUserByEmail(email, { redirectTo: `${SITE_URL}/invite/${token}` })`.
+
+  > **Regression guard (BF-38):** today's `inviteUser` already promotes `profiles.role` and upserts `organization_members` via `syncOrgMemberRole` (`dashboard/users/actions.ts:117-147`) at send-time. This rewrite defers membership + role to `/invite/[token]` acceptance — acceptance MUST insert the `organization_members` row *and* set `profiles.role` (see "Create-Project Path for New-Org Admins" below), or invitees lose the org-scoped RLS access BF-38 fixed. Relocate `syncOrgMemberRole`'s behavior into acceptance; don't drop it.
 - `src/app/invite/[token]/page.tsx` (new):
   1. Validates token (exists, not expired, not already accepted) via service client.
   2. If no session, redirect to `/login?invite_token=...` (login page preserves token).
-  3. If session and email matches invitation.email, insert `organization_members(org_id, user_id, role)`, mark `accepted_at`, redirect to `/dashboard`.
+  3. If session and email matches invitation.email, insert `organization_members(org_id, user_id, role)` **and, for `owner`/`admin` invites, set `profiles.role='admin'` in the same transaction** (else the new admin hits the create-project flash — see "Create-Project Path for New-Org Admins" / BF-46), mark `accepted_at`, redirect to `/dashboard`.
   4. If session but email mismatch, error page: "this invite is for a different email; please log out and retry".
 
 ### Signup restriction
@@ -82,6 +87,60 @@ WHERE p.id IS NULL;
 ```
 
 (Still uses `profiles.role='user'` default at this story — BF-34 migrates callers away from `profiles.role`, BF-35 drops the column.)
+
+## Create-Project Path for New-Org Admins (P0 — folded from BF-46)
+
+> **Folded from BF-46 (superseded 2026-06-08).** Andy's multi-tenant test: a freshly-provisioned admin (`adminbreen@pleniumbuilders.com`) could log in and was correctly isolated, but **could not create a project — "the screen just flashes."** It belongs here because it is a *latent defect in BF-33's own provisioning/invite flow*, not a standalone bug.
+
+### Root cause (prod-verified 2026-06-08)
+
+`getCurrentUser()` derives `role` from `profiles.role` (`src/lib/auth.ts:22`; default `'user'`). Prod confirmed `adminbreen`: `profiles.role='user'`, `org_id=NULL` (orphan — no membership, no org). Three gates key on `profiles.role`, all firing before any create:
+- `src/app/dashboard/projects/new/page.tsx:8` — `if (user.role !== "admin") redirect("/dashboard/projects")`, **before the form renders** = the flash.
+- `src/app/dashboard/projects/actions.ts:23` — a second admin gate, rejects before the org-membership query runs.
+- The **New Project button** (`projects/page.tsx:20-26,34-39`) renders for everyone with no gate, so non-admins can always click into the redirect.
+
+The membership/RLS paths (BF-46's original hypothesis) are unreachable for this user. The error banner already exists (`project-form.tsx:125-129`) and the RLS error is already mapped (`actions.ts:70-74`) — neither was the problem.
+
+**Why this is a BF-33 defect:** a new org's first owner is minted by the super-admin create-org route (doesn't exist yet) and accepted via `/invite/[token]` (also new) — neither sets `profiles.role`, and `handle_new_user` defaults it to `'user'`. So **a new org's first owner/admin — plus any user provisioned outside the existing `inviteUser`-as-admin path (self-signup, or invited as `user`, like `adminbreen`) — reproduces this exact flash** unless BF-33 sets `profiles.role` for them. (An admin invited through *today's* `inviteUser` already gets `role='admin'` + a membership in the inviting admin's org via BF-38's `syncOrgMemberRole`, so that path does **not** flash — but it can't mint a new org, which is the actual gap.) Fixing it here closes the bug at its source rather than papering over one user.
+
+### Fix
+
+1. **Provision `profiles.role='admin'` for org owners/admins** — in the super-admin create-org route (when adding an owner) and in `/invite/[token]` acceptance (for `owner`/`admin` invites), in the same transaction as the `organization_members` insert. Interim until BF-34 re-keys the gates off `profiles.role` and BF-35 drops the column — document the coupling.
+2. **Backfill `adminbreen` / Plenium so Andy can retest immediately** (orphan — create the org first):
+   ```sql
+   -- 1. create the Plenium org (via /admin/organizations/new once it lands, or manual MCP)
+   -- 2. promote the profile (WITHOUT this, the flash persists):
+   update profiles set role = 'admin' where id = '<adminbreen_user_id>';
+   -- 3. link membership (idempotent):
+   insert into organization_members (org_id, user_id, role)
+   values ('<plenium_org_id>', '<adminbreen_user_id>', 'admin')
+   on conflict (org_id, user_id) do update set role = 'admin';
+   ```
+3. **Loud failure for genuine non-admins:** hide/disable the New Project button for non-admins (`projects/page.tsx:20-26,34-39`), **or** remove the `new/page.tsx:8` redirect so the existing form banner can render the action error. Pick one — the page redirect currently makes an on-screen error impossible.
+4. **Harden error mapping (low-risk):** prefer `error.code === '42501'` over the message substring (keep the substring as fallback), applied to both `createProject` and `updateProject:228`; add `role="alert"` + scroll-into-view to the existing banner (`project-form.tsx:125-129`).
+
+### Ship order — land this slice first
+
+Steps 1-3 are **not** gated behind `NEXT_PUBLIC_MULTI_TENANT` and do **not** need BF-32. This is a small, flag-independent fix that should ship **ahead of** the org-switcher UI to unblock Andy's second-prospect UAT immediately; the switcher/invite-flow remainder follows under the flag.
+
+### Acceptance (folded from BF-46)
+
+- [x] Root cause confirmed against prod — `profiles.role='user'` page redirect, not membership/RLS. *(Done in validation 2026-06-08.)*
+- [ ] Provisioning an org owner/admin yields `profiles.role='admin'` + `organization_members(role IN ('owner','admin'))` + the org, atomically. *(DEFERRED to Slice 4 — durable super-admin create-org route. Slice 1 substituted a manual MCP backfill for adminbreen/Plenium.)*
+- [ ] `/invite/[token]` acceptance sets `profiles.role='admin'` for owner/admin invites (closes the latent flash for all future provisioned admins). *(DEFERRED to Slice 5 — invite-flow rewrite.)*
+- [x] `adminbreen@pleniumbuilders.com` backfilled (org + profile promote + membership) and can create a project end-to-end in Plenium; isolation still holds both ways. *(Backfill applied 2026-06-08 via MCP; Andy UAT confirmed create + both-way isolation 2026-06-09.)*
+- [x] A genuine non-admin gets a clear outcome (button hidden/disabled, or a rendered error) — never a silent flash. *(New Project links gated behind `isAdmin` in `projects/page.tsx`; `/verify` 9.7/10.)*
+- [x] `42501` mapping hardened on create + update; banner gets `role="alert"` + scroll-into-view. *(`actions.ts` createProject/updateProject; `project-form.tsx`.)*
+- [x] No regression to Q&D create-project. *(Andy isolation test 2026-06-09; admin create path unchanged.)*
+
+### Browser test (folded from BF-46)
+
+Vercel preview + a disposable second org (clean up after).
+1. **Repro (pre-fix):** provision a test admin the incomplete way (`profiles.role='user'`, no membership) → New Project → confirm the redirect-flash before any form renders (no `createProject` call in the network log).
+2. **Post-fix happy path:** provisioned admin (profile promoted + membership) creates a project → redirects to the project → appears in that org's list.
+3. **Isolation re-check:** a Q&D user can't see the test project; the test admin can't see Q&D projects.
+4. **Non-admin UX:** genuine non-admin → button hidden/disabled or a rendered error (no flash).
+5. **DB verify + cleanup:** correct `organization_id` on the new rows; delete the throwaway org/user/project after.
 
 ## Files
 
@@ -107,6 +166,10 @@ WHERE p.id IS NULL;
 - `src/components/sidebar.tsx` — footer sources org name from `activeOrg.name` when flag=1 (Q&D name intact when flag=0).
 - `src/app/dashboard/users/actions.ts` — `inviteUser` rewritten to org-scoped flow.
 - `src/app/signup/{page.tsx,actions.ts}` — invite-required flow.
+- `src/app/dashboard/projects/new/page.tsx` — non-admin handling (gate the button or drop the redirect) so the create path fails loudly, not silently. *(P0, folded from BF-46.)*
+- `src/app/dashboard/projects/page.tsx` — gate the New Project button for non-admins. *(P0, folded from BF-46.)*
+- `src/app/dashboard/projects/actions.ts` — harden RLS-error mapping (`42501`) on `createProject`/`updateProject`. *(P0, folded from BF-46.)*
+- `src/components/projects/project-form.tsx` — `role="alert"` + scroll-into-view on the existing error banner. *(P0, folded from BF-46.)*
 
 ## Pre-Flight
 
@@ -157,7 +220,7 @@ Schema rollback is not needed — BF-33 doesn't touch BF-30/31 tables.
 - Feature flag `=1` in production for 24h after code deploy, no runtime errors.
 - Andy test: given two test orgs, org switcher works correctly.
 - Single-org Q&D users see zero UX change.
-- Super-admin can provision a new prospect org end-to-end (create → invite owner → owner accepts → owner logs in to their new org's dashboard).
+- Super-admin can provision a new prospect org end-to-end (create → invite owner → owner accepts → owner logs in → **owner creates a project in their new org** — the BF-46 P0).
 - `organization_invitations` writes happen only through the new flow; old `auth.admin.inviteUserByEmail`-only path removed.
 
 ## Related

--- a/src/app/dashboard/projects/actions.ts
+++ b/src/app/dashboard/projects/actions.ts
@@ -68,7 +68,7 @@ export async function createProject(
     .single();
 
   if (projectError) {
-    if (projectError.message.includes("row-level security")) {
+    if (projectError.code === "42501" || projectError.message.includes("row-level security")) {
       return { error: "You don't have permission to create projects. Contact your administrator." };
     }
     return { error: projectError.message };
@@ -225,7 +225,7 @@ export async function updateProject(
     .eq("id", projectId);
 
   if (updateError) {
-    if (updateError.message.includes("row-level security")) {
+    if (updateError.code === "42501" || updateError.message.includes("row-level security")) {
       return { error: "You don't have permission to edit projects. Contact your administrator." };
     }
     return { error: updateError.message };

--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -1,10 +1,12 @@
 import Link from "next/link";
 import { Plus } from "lucide-react";
 import { getProjects } from "@/lib/queries/projects";
+import { getCurrentUser } from "@/lib/auth";
 import ProjectCard from "@/components/projects/ProjectCard";
 
 export default async function ProjectsPage() {
-  const projects = await getProjects();
+  const [projects, user] = await Promise.all([getProjects(), getCurrentUser()]);
+  const isAdmin = user?.role === "admin";
 
   return (
     <div>
@@ -17,13 +19,15 @@ export default async function ProjectsPage() {
             Manage your construction projects and compliance forms.
           </p>
         </div>
-        <Link
-          href="/dashboard/projects/new"
-          className="inline-flex items-center gap-2 rounded-md bg-[#5C6F8A] px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-[#4a5a6f]"
-        >
-          <Plus size={16} />
-          New Project
-        </Link>
+        {isAdmin && (
+          <Link
+            href="/dashboard/projects/new"
+            className="inline-flex items-center gap-2 rounded-md bg-[#5C6F8A] px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-[#4a5a6f]"
+          >
+            <Plus size={16} />
+            New Project
+          </Link>
+        )}
       </div>
 
       {projects.length === 0 ? (
@@ -31,12 +35,14 @@ export default async function ProjectsPage() {
           <p className="text-sm text-zinc-500 dark:text-zinc-400">
             No projects yet.
           </p>
-          <Link
-            href="/dashboard/projects/new"
-            className="mt-3 text-sm font-medium text-[#5C6F8A] hover:underline"
-          >
-            Create your first project
-          </Link>
+          {isAdmin && (
+            <Link
+              href="/dashboard/projects/new"
+              className="mt-3 text-sm font-medium text-[#5C6F8A] hover:underline"
+            >
+              Create your first project
+            </Link>
+          )}
         </div>
       ) : (
         <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/components/projects/project-form.tsx
+++ b/src/components/projects/project-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useState } from "react";
+import { useActionState, useEffect, useRef, useState } from "react";
 import { createProject, type ProjectState } from "@/app/dashboard/projects/actions";
 import {
   PERMIT_TYPES,
@@ -89,6 +89,11 @@ export default function ProjectForm({
 }: ProjectFormProps = {}) {
   const serverAction = action ?? createProject;
   const [state, formAction, pending] = useActionState(serverAction, initialState);
+  const errorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (state.error) errorRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [state.error]);
 
   const initialPermits = new Set<PermitType>(
     (existingPermits ?? []).map((p) => p.permit_type as PermitType)
@@ -123,7 +128,7 @@ export default function ProjectForm({
   return (
     <form action={formAction} className="space-y-8">
       {state.error && (
-        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950 dark:text-red-400">
+        <div ref={errorRef} role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950 dark:text-red-400">
           {state.error}
         </div>
       )}


### PR DESCRIPTION
## BF-33 Slice 1 — unblock new-org admin create-project (P0, folded from BF-46)

First of 5 slices of the BF-33 epic. Flag-independent, ships ahead of the org-switcher UI to unblock Andy's second-prospect UAT. Closes the "screen just flashes" bug for a freshly-provisioned org admin who couldn't create their first project.

**Root cause (prod-verified):** a new org's admin was left with `profiles.role='user'`, so `new/page.tsx` redirected them away *before the form rendered* — the flash. Fix = provision the role (done via backfill) + gate the button for genuine non-admins + harden the RLS-error path.

### Changes (3 files)
- **`projects/page.tsx`** — gate the New Project button behind `isAdmin` (both the header button and the empty-state link); fetched via `Promise.all` so no waterfall.
- **`projects/actions.ts`** — map Postgres `42501` (insufficient_privilege) in addition to the `row-level security` message substring, on both `createProject` and `updateProject`.
- **`project-form.tsx`** — `role="alert"` + scroll-into-view on the existing error banner so a real non-admin gets a visible outcome, never a silent flash.

### Verification (`/verify BF-33`, fresh session) — PASS 9.7/10
- ESLint: 0 errors (8 pre-existing warnings, none in changed files)
- `next build`: clean, 0 TS errors, full route table
- Live DB backfill confirmed: `adminbreen@pleniumbuilders.com` = `profiles.role='admin'`, owner of Plenium Builders only (isolated from Q&D); orgs 2 / members 7
- No regression to Q&D create-project

### Scope notes
- Provisioning the role *atomically inside* the super-admin create-org route and `/invite/[token]` acceptance is **deferred to Slices 4-5** (those routes don't exist yet). adminbreen was backfilled out-of-band via MCP so Andy can retest now.
- This branch deploys to a **Vercel preview** — production (master) is untouched.

### Outstanding gate — do not merge yet
- [ ] Andy end-to-end browser UAT on the preview: adminbreen creates a project in Plenium; isolation holds both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
