### PR TITLE
feat(ndot): BF-51 — mirror official NDOT form explanatory text (4 SP)

### DIFF
--- a/docs/sprints/sprint-3/stories/BF-51-ndot-form-helper-text-parity.md
+++ b/docs/sprints/sprint-3/stories/BF-51-ndot-form-helper-text-parity.md
@@ -1,0 +1,116 @@
+# BF-51: NDOT Form — Match Official NDOT Form Explanatory Text
+
+**Type:** UX / regulatory-parity copy
+**Priority:** MEDIUM (this is the headline ask Andy quoted in the email body)
+**Points:** 2 estimated → **4 actual** (full A+B+C parity across 4 render surfaces; deep research showed the ask is form-wide, not just the BMP table)
+**Status:** CODE COMPLETE — full parity (Tiers A+B+C) built across entry form, read-only view, and PDF. ESLint 0-err, `next build` clean. Pending: our browser pass + Andy/Gracie UAT.
+**Sprint:** 3
+**Reported by:** Gracie Damele via Andy Breen, email "BrAve Form Review" 2026-06-08 (`brave forms comments 1.pdf` p.4-6) + reference `NDOT Weekly Stormwater Logs.pdf` (official Form 018-001 WPCM, Rev. 1/04/2017)
+**Created:** 2026-06-08
+**Last Updated:** 2026-06-09T20:00:46Z
+
+## Problem
+
+The NDOT BMP checklist in our app renders each category as a bare label (e.g. "Track-Out") with Required/Implemented Y/N selects. The official NDOT form spells out a question per sub-section. NDOT reviewers expect the digital form to *look* like theirs. Andy quoted Gracie directly in the email body:
+
+> "I think in general just add some of the little explanations that are on the original NDOT form. Only because I know NDOT is kind of picky about things **'looking' similar even if the functionality is the same**."
+
+Annotated on `brave forms comments 1.pdf` p.4, repeated "same comment as previous" on p.5-6. The exact wording to mirror is in the supplied official form (`NDOT Weekly Stormwater Logs.pdf`, pages 1-3).
+
+## Reference text (from official Form 018-001 WPCM)
+
+Per BMP sub-section, the official form asks two questions; mirror both as helper text under each category name:
+
+| BMP Category | Line 1 (Required?) | Line 2 |
+|---|---|---|
+| Sediment Control | "Are sediment control measures required? If no, proceed to next sub-section." | "Are sediment control measures properly implemented?" |
+| Erosion Control | "Are erosion control measures required? If no, proceed to next sub-section." | "Are erosion control measures properly implemented?" |
+| Track-Out | "Are track-out measures required? If no, proceed to next sub-section." | "Are BMPs properly implemented?" |
+| Material Stockpiles | "Are there material stockpiles? If no, proceed to next sub-section." | "Are BMPs properly implemented?" |
+| Concrete Washout | "Are concrete washout areas required? If no, proceed to next sub-section." | "Are BMPs properly implemented?" |
+| Construction Material Storage | "Are construction materials stored onsite? If no, proceed to next sub-section." | "Are BMPs properly implemented?" |
+| Chemical Storage | "Are chemicals, e.g. equipment fluids, paints, solvents, etc., stored onsite? If no, proceed to next sub-section." | "Are BMPs properly implemented?" |
+| Fueling Areas | "Is there a temporary fueling area onsite? If no, proceed to next sub-section." | "Are BMPs properly implemented?" |
+| Construction Equipment | "Is there evidence of equipment leaks and/or spills? If no, proceed to the next sub-section." | "Are BMPs properly implemented?" |
+| Waste Material Storage | "Are waste materials stored onsite? If no, proceed to next sub-section." | "Are BMPs properly implemented?" |
+| Sanitation Facilities | "Are portable toilets staged onsite? If no, proceed to next sub-section." | "Are BMPs properly implemented?" |
+
+(Also review Section 1 conditional questions and Section 3 — Illicit Discharge / Spill Response / Final Check / Certification — against the official form for any short explanatory phrases worth mirroring. The 40 CFR 122.22(d) certification text already matches; confirm.)
+
+## Current state
+
+`src/components/forms/ndot-stormwater/Section2BmpCategories.tsx:31-82` renders a table; each row shows only `{item.name}` with Required/Implemented selects and a Comments input. Categories list: `src/lib/schemas/ndot-stormwater.ts:14-26` (the 11 names above, in order). No description/helper field exists on the category model today.
+
+## Proposed change
+
+Add the official sub-section helper text without changing the form's data model or submission shape.
+
+- **Source the text from a constant map** (category → `{ requiredPrompt, implementedPrompt }`) in `src/lib/constants/` or alongside `NDOT_BMP_CATEGORIES`. Do not inline 11 strings into JSX.
+- **Render it under each category name** as muted helper copy (e.g. small zinc text), two short lines, so the "Required" select reads against "Are X measures required? If no, proceed to next sub-section" and "Implemented" against "Are BMPs properly implemented?". Keep the table compact on mobile (these are field-used on tablets).
+- **Mirror NDOT's visual structure** closely enough to satisfy a picky reviewer — section grouping, the per-category prompt — but do **not** restructure the underlying data or break the existing PDF mapping.
+- **PDF parity:** confirm the generated NDOT PDF (`src/lib/pdf/` NDOT template) also reflects the official phrasing, since that's the artifact an NDOT reviewer actually receives. If the PDF already mirrors the official layout, note it; if not, add the prompts there too.
+
+## Acceptance criteria
+
+- [x] Each of the 11 BMP categories shows the official "required?" prompt and the "properly implemented?" prompt as helper text. *(all 3 surfaces: entry `Section2BmpCategories.tsx`, view `[submissionId]/page.tsx`, PDF `ndot-stormwater.tsx`.)*
+- [x] Wording matches Form 018-001 WPCM exactly (proofread against the supplied PDF). *(extracted official text verbatim into `src/lib/constants/ndot-form-text.ts`; incl. "Track-Out Control", Construction Equipment "the next sub-section", Sediment/Erosion "measures properly implemented".)*
+- [x] Helper text is sourced from a single constant, not duplicated in JSX. *(`src/lib/constants/ndot-form-text.ts` — one file feeds all 4 surfaces.)*
+- [x] Form data model + submission JSON shape unchanged (no migration; existing submissions still render). *(presentational only; prompts keyed by stored `bmp_categories[].name`; no schema touch. `next build` clean.)*
+- [ ] Layout holds on tablet/mobile widths (field devices). *(PENDING our browser pass — BMP table keeps `overflow-x-auto`, prompts wrap in the name cell; needs eyes on a tablet width.)*
+- [x] Generated NDOT PDF reflects the official phrasing. *(PDF rewritten: Instructions block added, BMP rendered as vertical prompt blocks, Site Assessment/SWPPP/Batch/Illicit/Final converted to full-width prompt+Y/N rows. Per Tim's call, page growth past 3 sheets is accepted.)*
+- [x] Section 1/3 reviewed and the official phrases added (Tier B). *(Conditional questions, SWPPP elements, batch/illicit/spill/final-check prompts all sourced from the constant; non-reportable-spill + non-structural-BMP prompts added to the PDF where they were missing.)*
+- [x] Certification text canonicalized (Tier C). *(One `NDOT_CERT_TEXT` constant — verbatim incl. the comma after "law" and `[40 CFR 122.22(d)]` brackets — replaces three previously-divergent hand-typed variants on entry/view/PDF.)*
+
+## Test plan — our browser testing before resubmitting to Andy
+
+1. Open NDOT Weekly Stormwater new form → Section 2 → confirm all 11 categories show both prompts, wording matches the PDF line-for-line (proofread side-by-side).
+2. Resize to tablet/phone widths → confirm no overflow, prompts still readable, selects still usable.
+3. Fill and submit a form → reopen (view + edit) → confirm helper text renders in all states and saved Y/N values are intact (data shape unaffected).
+4. Generate the NDOT PDF → compare against `NDOT Weekly Stormwater Logs.pdf` for phrasing/structure parity.
+5. Regression: open a pre-existing NDOT submission → confirm it still renders (helper text is presentational only).
+6. Screenshot side-by-side (our form vs official PDF) for the resubmission email so Andy/Gracie can see the parity.
+
+## Code review checklist
+
+- [ ] Helper strings live in one constant keyed by category; order matches `NDOT_BMP_CATEGORIES`.
+- [ ] No change to `ndot-stormwater.ts` schema / submission JSON keys.
+- [ ] Proofread: "the next sub-section" vs "next sub-section" matches the source per row (Construction Equipment uses "the next").
+- [ ] PDF template change (if any) doesn't shift pagination or break existing field positions.
+- [ ] Accessibility: helper text associated with its control (aria-describedby or adjacent label), not a floating div.
+
+## Validation findings (2026-06-08T16:53:50Z)
+
+Code-grounded review, **including a line-for-line proofread of the helper-text table against the official PDF** (extracted text). **Verdict: SOLID — unusually well-researched. Completeness, not correctness, is the risk.**
+
+- **Helper text verified verbatim.** All 11 rows match Form 018-001 exactly, including the two nuances the story already captured: Construction Equipment uses "proceed to **the** next sub-section" (only row with "the"); Sediment Control and Erosion Control use "Are X **measures** properly implemented?" for Line 2 (the other nine use "Are **BMPs** properly implemented?"). `NDOT_BMP_CATEGORIES` (`ndot-stormwater.ts:14-26`) lists the 11 names in the exact table order, so a helper map keyed by index **or** name aligns 1:1 (submissions always store 11 categories in fixed order via `makeDefaultBmpCategories`).
+- **PDF-template parity is the load-bearing half — make it required, not "confirm/if not, add."** `src/lib/pdf/ndot-stormwater.tsx:175-193` renders BMP rows as bare `{bmp.name}` + Y/N badges, no prompts. NDOT reviewers receive the **PDF**, so the prompts must go there too — and the test plan must verify the PDF still **paginates to 3 pages** matching the official form after the text is added.
+- **Mobile/tablet reflow may exceed the 2-SP estimate.** `Section2BmpCategories.tsx` is one `overflow-x-auto` table with fixed-width selects; two helper lines under 11 names inflate row height and worsen horizontal scroll on field tablets. A responsive stacked/card layout is more than "add muted zinc text" — re-check the estimate.
+- **Cert text is a NEAR-match, not exact** (the story says "already matches"). Template `CERT_TEXT` (`ndot-stormwater.tsx:38-39`) drops the comma after "law", adds "the" before "information", and omits the brackets around `[40 CFR 122.22(d)]`. The **on-screen** view-page cert (`[id]/forms/ndot-stormwater/[submissionId]/page.tsx:347-351`) is *more* divergent (drops whole clauses). For a verbatim-parity story, align them or downgrade the claim to "substantively equivalent."
+- **Category name parity:** app renders `Track-Out`; the official section header is `Track-Out Control`. Out of strict scope but a real visual-parity nit given the picky-reviewer driver — document as a known deviation or fix.
+- **Section 1 / Section 3 clauses are under-scoped.** The official form carries many short "If yes/no, briefly describe / proceed to next sub-section" phrases (Temporary Batch Plants, Illicit Discharge/Spill, Final Check, deficiency follow-up, non-structural BMPs). The story defers these as optional; a side-by-side picky review will flag their absence. List and decide them explicitly rather than hand-waving.
+
+## Deep research + build (2026-06-09)
+
+Read both ground-truth docs end-to-end (`Testing/NDOT Weekly Stormwater Logs.pdf` full text via `Testing/ndot_pdf_text.txt`; `Testing/brave forms comments 1.pdf` extracted) and diffed against every render surface. Tim's calls: **A+B+C full parity · accept PDF page growth · canonicalize cert · include the read-only view.** Built accordingly.
+
+**Scope was wider than the original story.** Gracie's driver (comments PDF p.4) is *"in general just add some of the little explanations that are on the original NDOT form…NDOT is kind of picky about things 'looking' similar"* — and p.5-6 are "same comment as previous" on the next two NDOT-form screenshots. So the ask spans the **whole form**, not just the 11 BMP categories. Every Section 1 / SWPPP / Section 3 question in our app was abbreviated the same way the BMP names were.
+
+**Correction to the prior validation finding:** the claim "the 40 CFR 122.22(d) certification text already matches; confirm" was **WRONG**. Three surfaces carried three *different*, all-divergent cert strings: entry form (present-tense "gather and evaluate"; parens), PDF (no comma after "law"; added "the"; no brackets), and the read-only view (**dropped the entire second half**). All three now render one canonical `NDOT_CERT_TEXT` constant, verbatim from the official form.
+
+**Single source of truth:** `src/lib/constants/ndot-form-text.ts` holds every official string (instructions, cert, BMP prompts keyed by category name w/ `displayName` for Track-Out→"Track-Out Control", Section 1 conditional prompts, SWPPP prompts, Section 3 prompts). All four surfaces import from it.
+
+**Four surfaces touched (the story named two):**
+- `src/components/forms/ndot-stormwater/Section2BmpCategories.tsx` — BMP prompts under each name as helper text, `aria-describedby` wiring prompts to the Required/Implemented selects (a11y AC). Covers **new + edit** (both reuse this component via `NdotStormwaterForm`).
+- `src/components/forms/ndot-stormwater/Section1SiteInfo.tsx` — full official prompts on conditional questions + SWPPP; site-info hints (Project Location, CSW full name, precip total).
+- `src/components/forms/ndot-stormwater/Section3DischargeSignatures.tsx` — full prompts on batch/illicit/spill/final-check; cert → constant.
+- `src/components/forms/ndot-stormwater/NdotStormwaterForm.tsx` — Instructions paragraph at top of form.
+- `src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/page.tsx` — **read-only view** (the surface the story missed): BMP prompts, Section 1/3 full prompts (normal-case `questionClass`, since the view's tiny-caps labels would mangle sentences), cert → constant.
+- `src/lib/pdf/ndot-stormwater.tsx` — **the artifact NDOT receives**: Instructions block; BMP rendered as vertical prompt blocks; Site Assessment / SWPPP / Batch / Illicit / Final converted from compact multi-column rows to full-width prompt+Y/N rows (mirrors the official's vertical layout); added the non-reportable-spill + non-structural-BMP prompts that were missing; cert → constant. Page growth past 3 sheets accepted per Tim.
+
+**Verification:** ESLint 0 errors (8 pre-existing warnings, none in changed logic). `next build` clean (type-check passes). Browser/tablet pass + UAT still pending.
+
+## Out of scope
+
+- Autofill / auto-increment (BF-50).
+- Adding/removing actual BMP categories or changing Y/N semantics.
+- NDEP and NNPH form copy (NDEP had no annotations this round; NNPH is BF-52).

--- a/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/forms/ndot-stormwater/[submissionId]/page.tsx
@@ -13,6 +13,13 @@ import {
   headerCellClass,
   cellClass,
 } from "@/components/forms/formStyles";
+import {
+  NDOT_BMP_PROMPTS,
+  NDOT_SECTION1_PROMPTS,
+  NDOT_SWPPP_PROMPTS,
+  NDOT_SECTION3_PROMPTS,
+  NDOT_CERT_TEXT,
+} from "@/lib/constants/ndot-form-text";
 
 const statusBadge: Record<string, string> = {
   draft: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
@@ -23,6 +30,9 @@ const statusBadge: Record<string, string> = {
 
 const labelClass = "text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400";
 const valueClass = "mt-1 text-sm text-zinc-900 dark:text-zinc-100";
+// Full official NDOT prompts read as sentences — normal case, not the tiny-caps labelClass (BF-51).
+const questionClass = "text-xs font-medium leading-snug text-zinc-600 dark:text-zinc-400";
+const bmpPromptClass = "mt-0.5 text-xs font-normal leading-snug text-zinc-500 dark:text-zinc-400";
 
 function YNBadge({ value }: { value?: string }) {
   if (value === "Y") return <span className="text-green-700 dark:text-green-400 font-medium">Y</span>;
@@ -179,25 +189,25 @@ export default async function NdotStormwaterViewPage({
         </h3>
         <div className="grid gap-4 sm:grid-cols-2">
           <div>
-            <p className={labelClass}>Discharge to TMDL Waterway?</p>
+            <p className={questionClass}>{NDOT_SECTION1_PROMPTS.tmdl_waterway}</p>
             <p className={valueClass}><YNBadge value={data.tmdl_waterway} /></p>
             {data.tmdl_waterway === "Y" && data.tmdl_waterway_names && (
               <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{data.tmdl_waterway_names}</p>
             )}
           </div>
           <div>
-            <p className={labelClass}>Deficiency Follow-up?</p>
+            <p className={questionClass}>{NDOT_SECTION1_PROMPTS.deficiency_followup}</p>
             <p className={valueClass}>{DEFICIENCY_LABELS[data.deficiency_followup ?? ""] ?? "—"}</p>
             {data.deficiency_followup === "yes" && data.deficiency_actions && (
               <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{data.deficiency_actions}</p>
             )}
           </div>
           <div>
-            <p className={labelClass}>Evidence of Erosion?</p>
+            <p className={questionClass}>{NDOT_SECTION1_PROMPTS.erosion_evidence}</p>
             <p className={valueClass}><YNBadge value={data.erosion_evidence} /></p>
             {data.erosion_evidence === "Y" && (
               <>
-                <p className="mt-1 text-xs text-zinc-500">Discharge: <YNBadge value={data.erosion_discharge} /></p>
+                <p className="mt-1 text-xs text-zinc-500">{NDOT_SECTION1_PROMPTS.erosion_discharge} <YNBadge value={data.erosion_discharge} /></p>
                 {data.erosion_waterway && (
                   <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{data.erosion_waterway}</p>
                 )}
@@ -205,11 +215,11 @@ export default async function NdotStormwaterViewPage({
             )}
           </div>
           <div>
-            <p className={labelClass}>Adjacent Property Runoff?</p>
+            <p className={questionClass}>{NDOT_SECTION1_PROMPTS.adjacent_runoff}</p>
             <p className={valueClass}><YNBadge value={data.adjacent_runoff} /></p>
           </div>
           <div>
-            <p className={labelClass}>Pollutant Concerns?</p>
+            <p className={questionClass}>{NDOT_SECTION1_PROMPTS.pollutant_concerns}</p>
             <p className={valueClass}><YNBadge value={data.pollutant_concerns} /></p>
             {data.pollutant_concerns === "Y" && data.pollutant_explain && (
               <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{data.pollutant_explain}</p>
@@ -222,10 +232,10 @@ export default async function NdotStormwaterViewPage({
           SWPPP Elements
         </h3>
         <div className="grid gap-4 sm:grid-cols-4">
-          <div><p className={labelClass}>On-site?</p><p className={valueClass}><YNBadge value={data.swppp_onsite} /></p></div>
-          <div><p className={labelClass}>Signed?</p><p className={valueClass}><YNBadge value={data.swppp_signed} /></p></div>
-          <div><p className={labelClass}>Current?</p><p className={valueClass}><YNBadge value={data.swppp_current} /></p></div>
-          <div><p className={labelClass}>NOI Posted?</p><p className={valueClass}><YNBadge value={data.swppp_posted} /></p></div>
+          <div><p className={questionClass}>{NDOT_SWPPP_PROMPTS.swppp_onsite}</p><p className={valueClass}><YNBadge value={data.swppp_onsite} /></p></div>
+          <div><p className={questionClass}>{NDOT_SWPPP_PROMPTS.swppp_signed}</p><p className={valueClass}><YNBadge value={data.swppp_signed} /></p></div>
+          <div><p className={questionClass}>{NDOT_SWPPP_PROMPTS.swppp_current}</p><p className={valueClass}><YNBadge value={data.swppp_current} /></p></div>
+          <div><p className={questionClass}>{NDOT_SWPPP_PROMPTS.swppp_posted}</p><p className={valueClass}><YNBadge value={data.swppp_posted} /></p></div>
         </div>
       </section>
 
@@ -246,14 +256,25 @@ export default async function NdotStormwaterViewPage({
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
-              {bmps.map((bmp) => (
+              {bmps.map((bmp) => {
+                const prompt = NDOT_BMP_PROMPTS[bmp.name as keyof typeof NDOT_BMP_PROMPTS];
+                return (
                 <tr key={bmp.name}>
-                  <td className={`${cellClass} text-sm font-medium text-zinc-700 dark:text-zinc-300`}>{bmp.name}</td>
+                  <td className={`${cellClass} max-w-md`}>
+                    <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">{prompt?.displayName ?? bmp.name}</span>
+                    {prompt && (
+                      <>
+                        <p className={bmpPromptClass}>{prompt.required}</p>
+                        <p className={`${bmpPromptClass} mt-1`}>{prompt.implemented}</p>
+                      </>
+                    )}
+                  </td>
                   <td className={cellClass}><YNBadge value={bmp.required} /></td>
                   <td className={cellClass}><YNBadge value={bmp.implemented} /></td>
                   <td className={`${cellClass} text-sm text-zinc-600 dark:text-zinc-400`}>{bmp.comments || "—"}</td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>
@@ -301,7 +322,7 @@ export default async function NdotStormwaterViewPage({
           Temporary Batch Plants
         </h3>
         <div className="grid gap-4 sm:grid-cols-3">
-          <div><p className={labelClass}>Present?</p><p className={valueClass}><YNBadge value={data.batch_plant_present} /></p></div>
+          <div><p className={questionClass}>{NDOT_SECTION3_PROMPTS.batch_plant_present}</p><p className={valueClass}><YNBadge value={data.batch_plant_present} /></p></div>
           {data.batch_plant_present === "Y" && (
             <>
               <div><p className={labelClass}>Location</p><p className={valueClass}>{data.batch_plant_location === "onsite" ? "On-site" : data.batch_plant_location === "offsite" ? "Off-site" : "—"}</p></div>
@@ -318,23 +339,23 @@ export default async function NdotStormwaterViewPage({
           Illicit Discharge / Spill Response
         </h3>
         <div className="grid gap-4 sm:grid-cols-3">
-          <div><p className={labelClass}>Illicit Discharges?</p><p className={valueClass}><YNBadge value={data.illicit_discharges} /></p></div>
-          <div><p className={labelClass}>Reportable Spills?</p><p className={valueClass}><YNBadge value={data.reportable_spills} /></p></div>
-          <div><p className={labelClass}>NDEP Report Filed?</p><p className={valueClass}><YNBadge value={data.ndep_report_filed} /></p></div>
+          <div><p className={questionClass}>{NDOT_SECTION3_PROMPTS.illicit_discharges}</p><p className={valueClass}><YNBadge value={data.illicit_discharges} /></p></div>
+          <div><p className={questionClass}>{NDOT_SECTION3_PROMPTS.reportable_spills}</p><p className={valueClass}><YNBadge value={data.reportable_spills} /></p></div>
+          <div><p className={questionClass}>{NDOT_SECTION3_PROMPTS.ndep_report_filed}</p><p className={valueClass}><YNBadge value={data.ndep_report_filed} /></p></div>
         </div>
         {data.reportable_spills === "Y" && data.spill_action && (
           <div><p className={labelClass}>Spill Action Taken</p><p className={valueClass}>{data.spill_action}</p></div>
         )}
         <div className="grid gap-4 sm:grid-cols-2">
-          <div><p className={labelClass}>Non-reportable Spills?</p><p className={valueClass}><YNBadge value={data.non_reportable_spills} /></p></div>
+          <div><p className={questionClass}>{NDOT_SECTION3_PROMPTS.non_reportable_spills}</p><p className={valueClass}><YNBadge value={data.non_reportable_spills} /></p></div>
         </div>
 
         {/* Additional */}
         {data.non_structural_bmps && (
-          <div><p className={labelClass}>Non-structural BMPs</p><p className={valueClass}>{data.non_structural_bmps}</p></div>
+          <div><p className={questionClass}>{NDOT_SECTION3_PROMPTS.non_structural_bmps}</p><p className={valueClass}>{data.non_structural_bmps}</p></div>
         )}
         <div className="grid gap-4 sm:grid-cols-2">
-          <div><p className={labelClass}>All Areas Inspected?</p><p className={valueClass}><YNBadge value={data.all_areas_inspected} /></p></div>
+          <div><p className={questionClass}>{NDOT_SECTION3_PROMPTS.all_areas_inspected}</p><p className={valueClass}><YNBadge value={data.all_areas_inspected} /></p></div>
         </div>
         {data.additional_comments && (
           <div><p className={labelClass}>Additional Comments</p><p className={valueClass}>{data.additional_comments}</p></div>
@@ -344,10 +365,8 @@ export default async function NdotStormwaterViewPage({
         <h3 className="text-sm font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-400">
           Certification
         </h3>
-        <p className="text-xs italic text-zinc-500 dark:text-zinc-400">
-          I certify under penalty of law that this document and all attachments were prepared under my
-          direction or supervision in accordance with a system designed to assure that qualified personnel
-          properly gather and evaluate the information submitted. (40 CFR 122.22(d))
+        <p className="text-xs italic text-zinc-500 dark:text-zinc-400 leading-relaxed">
+          {NDOT_CERT_TEXT}
         </p>
         <div className="grid gap-4 sm:grid-cols-2 rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
           <div>

--- a/src/components/forms/ndot-stormwater/NdotStormwaterForm.tsx
+++ b/src/components/forms/ndot-stormwater/NdotStormwaterForm.tsx
@@ -16,6 +16,7 @@ import Section2BmpCategories from "./Section2BmpCategories";
 import Section3DischargeSignatures from "./Section3DischargeSignatures";
 import PhotoAttachment from "@/components/forms/shared/PhotoAttachment";
 import type { FormPhoto } from "@/lib/schemas/ndot-stormwater";
+import { NDOT_INSTRUCTIONS } from "@/lib/constants/ndot-form-text";
 
 interface NdotStormwaterFormProps {
   projectId: string;
@@ -172,6 +173,11 @@ export default function NdotStormwaterForm({
             Pre-filled from last submission (date/signatures cleared)
           </span>
         )}
+      </div>
+
+      <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs leading-relaxed text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-400">
+        <span className="font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Instructions: </span>
+        {NDOT_INSTRUCTIONS}
       </div>
 
       <Section1SiteInfo data={data} onChange={update} fieldErrors={state.fieldErrors} />

--- a/src/components/forms/ndot-stormwater/Section1SiteInfo.tsx
+++ b/src/components/forms/ndot-stormwater/Section1SiteInfo.tsx
@@ -10,6 +10,13 @@ import {
   TEMP_RANGES_LIST,
   type NdotStormwaterData,
 } from "@/lib/schemas/ndot-stormwater";
+import {
+  NDOT_SECTION1_PROMPTS,
+  NDOT_SWPPP_PROMPTS,
+  NDOT_SITE_INFO_HINTS,
+} from "@/lib/constants/ndot-form-text";
+
+const hintClass = "mt-0.5 text-xs font-normal italic text-zinc-400 dark:text-zinc-500";
 
 interface Section1Props {
   data: NdotStormwaterData;
@@ -57,6 +64,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
             readOnly
             className={readOnlyInputClass}
           />
+          <p className={hintClass}>{NDOT_SITE_INFO_HINTS.project_location}</p>
         </div>
         <div>
           <label className={labelClass}>Contract Number</label>
@@ -91,6 +99,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
             disabled={data.csw_na}
             className={`${inputClass} ${data.csw_na ? "opacity-50" : ""}`}
           />
+          <p className={hintClass}>{NDOT_SITE_INFO_HINTS.csw_tracking}</p>
         </div>
         <div>
           <label className={labelClass}>NDOT Inspector</label>
@@ -274,6 +283,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
             className={`${inputClass} ${data.precip_na ? "opacity-50" : ""}`}
             placeholder="0.00"
           />
+          <p className={hintClass}>{NDOT_SITE_INFO_HINTS.precip_total}</p>
         </div>
       </div>
 
@@ -285,7 +295,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
       {/* Q1: TMDL Waterway */}
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label className={labelClass}>Discharge to TMDL waterway?</label>
+          <label className={labelClass}>{NDOT_SECTION1_PROMPTS.tmdl_waterway}</label>
           <select
             value={data.tmdl_waterway ?? ""}
             onChange={(e) => onChange("tmdl_waterway", e.target.value as "Y" | "N")}
@@ -298,7 +308,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
         </div>
         {data.tmdl_waterway === "Y" && (
           <div>
-            <label className={labelClass}>Waterway Name(s)</label>
+            <label className={labelClass}>{NDOT_SECTION1_PROMPTS.tmdl_waterway_names}</label>
             <input
               type="text"
               value={data.tmdl_waterway_names}
@@ -312,7 +322,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
       {/* Q2: Deficiency Follow-up */}
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label className={labelClass}>Deficiency follow-up required?</label>
+          <label className={labelClass}>{NDOT_SECTION1_PROMPTS.deficiency_followup}</label>
           <select
             value={data.deficiency_followup ?? ""}
             onChange={(e) =>
@@ -343,7 +353,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
       {/* Q3: Erosion Evidence */}
       <div className="grid gap-4 sm:grid-cols-3">
         <div>
-          <label className={labelClass}>Evidence of erosion?</label>
+          <label className={labelClass}>{NDOT_SECTION1_PROMPTS.erosion_evidence}</label>
           <select
             value={data.erosion_evidence ?? ""}
             onChange={(e) => onChange("erosion_evidence", e.target.value as "Y" | "N")}
@@ -357,7 +367,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
         {data.erosion_evidence === "Y" && (
           <>
             <div>
-              <label className={labelClass}>Discharge to waterway?</label>
+              <label className={labelClass}>{NDOT_SECTION1_PROMPTS.erosion_discharge}</label>
               <select
                 value={data.erosion_discharge ?? ""}
                 onChange={(e) => onChange("erosion_discharge", e.target.value as "Y" | "N")}
@@ -369,7 +379,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
               </select>
             </div>
             <div>
-              <label className={labelClass}>Waterway Name</label>
+              <label className={labelClass}>{NDOT_SECTION1_PROMPTS.erosion_waterway}</label>
               <input
                 type="text"
                 value={data.erosion_waterway}
@@ -384,7 +394,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
       {/* Q4: Adjacent Runoff */}
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label className={labelClass}>Adjacent property runoff concerns?</label>
+          <label className={labelClass}>{NDOT_SECTION1_PROMPTS.adjacent_runoff}</label>
           <select
             value={data.adjacent_runoff ?? ""}
             onChange={(e) => onChange("adjacent_runoff", e.target.value as "Y" | "N")}
@@ -400,7 +410,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
       {/* Q5: Pollutant Concerns */}
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label className={labelClass}>Pollutant concerns identified?</label>
+          <label className={labelClass}>{NDOT_SECTION1_PROMPTS.pollutant_concerns}</label>
           <select
             value={data.pollutant_concerns ?? ""}
             onChange={(e) => onChange("pollutant_concerns", e.target.value as "Y" | "N")}
@@ -431,7 +441,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
       </h3>
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-4">
         <div>
-          <label className={labelClass}>SWPPP On-Site?</label>
+          <label className={labelClass}>{NDOT_SWPPP_PROMPTS.swppp_onsite}</label>
           <select
             value={data.swppp_onsite ?? ""}
             onChange={(e) => onChange("swppp_onsite", e.target.value as "Y" | "N")}
@@ -443,7 +453,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
           </select>
         </div>
         <div>
-          <label className={labelClass}>SWPPP Signed?</label>
+          <label className={labelClass}>{NDOT_SWPPP_PROMPTS.swppp_signed}</label>
           <select
             value={data.swppp_signed ?? ""}
             onChange={(e) => onChange("swppp_signed", e.target.value as "Y" | "N")}
@@ -455,7 +465,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
           </select>
         </div>
         <div>
-          <label className={labelClass}>SWPPP Current?</label>
+          <label className={labelClass}>{NDOT_SWPPP_PROMPTS.swppp_current}</label>
           <select
             value={data.swppp_current ?? ""}
             onChange={(e) => onChange("swppp_current", e.target.value as "Y" | "N")}
@@ -467,7 +477,7 @@ export default function Section1SiteInfo({ data, onChange, fieldErrors }: Sectio
           </select>
         </div>
         <div>
-          <label className={labelClass}>NOI Posted?</label>
+          <label className={labelClass}>{NDOT_SWPPP_PROMPTS.swppp_posted}</label>
           <select
             value={data.swppp_posted ?? ""}
             onChange={(e) => onChange("swppp_posted", e.target.value as "Y" | "N")}

--- a/src/components/forms/ndot-stormwater/Section2BmpCategories.tsx
+++ b/src/components/forms/ndot-stormwater/Section2BmpCategories.tsx
@@ -8,6 +8,9 @@ import type {
   NdotStormwaterData,
   BmpCategory,
 } from "@/lib/schemas/ndot-stormwater";
+import { NDOT_BMP_PROMPTS } from "@/lib/constants/ndot-form-text";
+
+const promptClass = "mt-0.5 text-xs font-normal leading-snug text-zinc-500 dark:text-zinc-400";
 
 interface Section2Props {
   data: NdotStormwaterData;
@@ -39,16 +42,30 @@ export default function Section2BmpCategories({ data, onChange }: Section2Props)
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
-            {data.bmp_categories.map((item, i) => (
+            {data.bmp_categories.map((item, i) => {
+              const prompt = NDOT_BMP_PROMPTS[item.name as keyof typeof NDOT_BMP_PROMPTS];
+              const reqId = `bmp-${i}-required`;
+              const implId = `bmp-${i}-implemented`;
+              return (
               <tr key={item.name}>
-                <td className={`${cellClass} text-sm font-medium text-zinc-700 dark:text-zinc-300`}>
-                  {item.name}
+                <td className={`${cellClass} max-w-md`}>
+                  <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    {prompt?.displayName ?? item.name}
+                  </span>
+                  {prompt && (
+                    <>
+                      <p id={reqId} className={promptClass}>{prompt.required}</p>
+                      <p id={implId} className={`${promptClass} mt-1`}>{prompt.implemented}</p>
+                    </>
+                  )}
                 </td>
                 <td className={cellClass}>
                   <select
                     value={item.required}
                     onChange={(e) => updateBmp(i, "required", e.target.value)}
                     className={selectClass}
+                    aria-label={`${item.name} — required`}
+                    aria-describedby={prompt ? reqId : undefined}
                   >
                     <option value="Y">Y</option>
                     <option value="N">N</option>
@@ -59,6 +76,8 @@ export default function Section2BmpCategories({ data, onChange }: Section2Props)
                     value={item.implemented}
                     onChange={(e) => updateBmp(i, "implemented", e.target.value)}
                     className={selectClass}
+                    aria-label={`${item.name} — implemented`}
+                    aria-describedby={prompt ? implId : undefined}
                   >
                     <option value="Y">Y</option>
                     <option value="N">N</option>
@@ -73,7 +92,8 @@ export default function Section2BmpCategories({ data, onChange }: Section2Props)
                   />
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/src/components/forms/ndot-stormwater/Section3DischargeSignatures.tsx
+++ b/src/components/forms/ndot-stormwater/Section3DischargeSignatures.tsx
@@ -4,6 +4,7 @@ import {
   labelClass,
 } from "@/components/forms/formStyles";
 import type { NdotStormwaterData } from "@/lib/schemas/ndot-stormwater";
+import { NDOT_SECTION3_PROMPTS, NDOT_CERT_TEXT } from "@/lib/constants/ndot-form-text";
 
 interface Section3Props {
   data: NdotStormwaterData;
@@ -30,7 +31,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
       </h3>
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label className={labelClass}>Batch plant present?</label>
+          <label className={labelClass}>{NDOT_SECTION3_PROMPTS.batch_plant_present}</label>
           <select
             value={data.batch_plant_present ?? ""}
             onChange={(e) => onChange("batch_plant_present", e.target.value as "Y" | "N")}
@@ -43,7 +44,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
         </div>
         {data.batch_plant_present === "Y" && (
           <div>
-            <label className={labelClass}>Location</label>
+            <label className={labelClass}>{NDOT_SECTION3_PROMPTS.batch_plant_location}</label>
             <select
               value={data.batch_plant_location ?? ""}
               onChange={(e) =>
@@ -88,7 +89,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
       </h3>
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label className={labelClass}>Illicit discharges observed?</label>
+          <label className={labelClass}>{NDOT_SECTION3_PROMPTS.illicit_discharges}</label>
           <select
             value={data.illicit_discharges ?? ""}
             onChange={(e) => onChange("illicit_discharges", e.target.value as "Y" | "N")}
@@ -100,7 +101,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
           </select>
         </div>
         <div>
-          <label className={labelClass}>Reportable spills?</label>
+          <label className={labelClass}>{NDOT_SECTION3_PROMPTS.reportable_spills}</label>
           <select
             value={data.reportable_spills ?? ""}
             onChange={(e) => onChange("reportable_spills", e.target.value as "Y" | "N")}
@@ -116,7 +117,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
       {data.reportable_spills === "Y" && (
         <div className="grid gap-4 sm:grid-cols-2">
           <div>
-            <label className={labelClass}>Spill Action Taken</label>
+            <label className={labelClass}>{NDOT_SECTION3_PROMPTS.spill_action}</label>
             <textarea
               value={data.spill_action}
               onChange={(e) => onChange("spill_action", e.target.value)}
@@ -126,7 +127,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
             />
           </div>
           <div>
-            <label className={labelClass}>NDEP report filed?</label>
+            <label className={labelClass}>{NDOT_SECTION3_PROMPTS.ndep_report_filed}</label>
             <select
               value={data.ndep_report_filed ?? ""}
               onChange={(e) => onChange("ndep_report_filed", e.target.value as "Y" | "N")}
@@ -142,7 +143,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label className={labelClass}>Non-reportable spills?</label>
+          <label className={labelClass}>{NDOT_SECTION3_PROMPTS.non_reportable_spills}</label>
           <select
             value={data.non_reportable_spills ?? ""}
             onChange={(e) => onChange("non_reportable_spills", e.target.value as "Y" | "N")}
@@ -161,7 +162,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
       </h3>
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label className={labelClass}>Non-structural BMPs</label>
+          <label className={labelClass}>{NDOT_SECTION3_PROMPTS.non_structural_bmps}</label>
           <textarea
             value={data.non_structural_bmps}
             onChange={(e) => onChange("non_structural_bmps", e.target.value)}
@@ -170,7 +171,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
           />
         </div>
         <div>
-          <label className={labelClass}>All areas inspected?</label>
+          <label className={labelClass}>{NDOT_SECTION3_PROMPTS.all_areas_inspected}</label>
           <select
             value={data.all_areas_inspected ?? ""}
             onChange={(e) => onChange("all_areas_inspected", e.target.value as "Y" | "N")}
@@ -197,14 +198,7 @@ export default function Section3DischargeSignatures({ data, onChange, fieldError
         Certification
       </h3>
       <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed">
-        I certify under penalty of law that this document and all attachments were prepared under my
-        direction or supervision in accordance with a system designed to assure that qualified
-        personnel properly gather and evaluate the information submitted. Based on my inquiry of the
-        person or persons who manage the system, or those persons directly responsible for gathering
-        the information, the information submitted is, to the best of my knowledge and belief, true,
-        accurate, and complete. I am aware that there are significant penalties for submitting false
-        information, including the possibility of fine and imprisonment for knowing violations.
-        (40 CFR 122.22(d))
+        {NDOT_CERT_TEXT}
       </p>
 
       {/* Dual Signatures */}

--- a/src/lib/constants/ndot-form-text.ts
+++ b/src/lib/constants/ndot-form-text.ts
@@ -1,0 +1,143 @@
+// Official NDOT Form 018-001 WPCM (Rev. 1/04/2017) explanatory text.
+//
+// Verbatim from the official form (State of Nevada DOT, "Construction Site
+// Stormwater Inspection Form For Water Pollution Control Managers"). Mirrored so
+// the digital form "looks" similar to NDOT's — NDOT reviewers are picky about
+// visual parity even when functionality is identical (Gracie Damele, BF-51).
+//
+// PRESENTATIONAL ONLY. These strings are display copy keyed by field/category;
+// they do NOT change the submission JSON shape or any schema key. The BMP map is
+// keyed by the canonical category `name` stored in `bmp_categories[].name`, so
+// existing submissions render unchanged.
+
+import { NDOT_BMP_CATEGORIES } from "@/lib/schemas/ndot-stormwater";
+
+type BmpCategoryName = (typeof NDOT_BMP_CATEGORIES)[number];
+
+// --- Form header instructions (official p.1) ---
+
+export const NDOT_INSTRUCTIONS =
+  `Conduct the inspection in the presence of the Department designated personnel and discuss your observations. Ask clarifying questions when needed. Provide a brief description of deficiencies in the appropriate "Comment Section." Utilize the "Additional Comments" section at the end of the document as necessary. Attach digital photographs of deficiencies or other noted issues of concern with the inspection form. Areas disturbed by construction activities that are not permanently stabilized and discharge into a receiving waterway or storm drain system shall have inspection priority. For projects that do not have a Resident Engineer, list the individual(s) responsible for construction administration.`;
+
+// --- Canonical certification statement [40 CFR 122.22(d)] (official p.3) ---
+// Single source of truth — entry form, read-only view, and PDF all render this
+// exact string. Replaces three previously-divergent hand-typed variants.
+
+export const NDOT_CERT_TEXT =
+  `I certify under penalty of law, that this document and all attachments were prepared under my direction or supervision in accordance with a system designed to assure that qualified personnel properly gathered and evaluated the information submitted. Based on my inquiry of the person or persons who manage the system, or those persons directly responsible for gathering information, the information submitted is, to the best of my knowledge and belief, true, accurate, and complete. I am aware that there are significant penalties for submitting false information, including the possibility of fine and imprisonment for knowing violations. [40 CFR 122.22(d)]`;
+
+// --- BMP sub-section prompts (official p.1-2) ---
+// `displayName` overrides the on-screen/PDF heading WITHOUT changing the stored
+// `name` key (only Track-Out differs from the official sub-section header).
+
+export interface BmpPrompt {
+  /** Override the visible heading; stored `name` is unaffected. */
+  displayName?: string;
+  /** "Are X required? If no, proceed to next sub-section." */
+  required: string;
+  /** "Are BMPs/X measures properly implemented?" */
+  implemented: string;
+}
+
+export const NDOT_BMP_PROMPTS: Record<BmpCategoryName, BmpPrompt> = {
+  "Sediment Control": {
+    required: "Are sediment control measures required? If no, proceed to next sub-section.",
+    implemented: "Are sediment control measures properly implemented?",
+  },
+  "Erosion Control": {
+    required: "Are erosion control measures required? If no, proceed to next sub-section.",
+    implemented: "Are erosion control measures properly implemented?",
+  },
+  "Track-Out": {
+    displayName: "Track-Out Control",
+    required: "Are track-out measures required? If no, proceed to next sub-section.",
+    implemented: "Are BMPs properly implemented?",
+  },
+  "Material Stockpiles": {
+    required: "Are there material stockpiles? If no, proceed to next sub-section.",
+    implemented: "Are BMPs properly implemented?",
+  },
+  "Concrete Washout": {
+    required: "Are concrete washout areas required? If no, proceed to next sub-section.",
+    implemented: "Are BMPs properly implemented?",
+  },
+  "Construction Material Storage": {
+    required: "Are construction materials stored onsite? If no, proceed to next sub-section.",
+    implemented: "Are BMPs properly implemented?",
+  },
+  "Chemical Storage": {
+    required:
+      "Are chemicals, e.g. equipment fluids, paints, solvents, etc., stored onsite? If no, proceed to next sub-section.",
+    implemented: "Are BMPs properly implemented?",
+  },
+  "Fueling Areas": {
+    required: "Is there a temporary fueling area onsite? If no, proceed to next sub-section.",
+    implemented: "Are BMPs properly implemented?",
+  },
+  "Construction Equipment": {
+    // Only sub-section whose official wording reads "the next sub-section".
+    required: "Is there evidence of equipment leaks and/or spills? If no, proceed to the next sub-section.",
+    implemented: "Are BMPs properly implemented?",
+  },
+  "Waste Material Storage": {
+    required: "Are waste materials stored onsite? If no, proceed to next sub-section.",
+    implemented: "Are BMPs properly implemented?",
+  },
+  "Sanitation Facilities": {
+    required: "Are portable toilets staged onsite? If no, proceed to next sub-section.",
+    implemented: "Are BMPs properly implemented?",
+  },
+};
+
+// --- Section 1: Site Information field hints (official p.1) ---
+
+export const NDOT_SITE_INFO_HINTS = {
+  project_location: "Description from Contract Documents",
+  csw_tracking: "Construction General Permit CSW/Tracking Number",
+  precip_total: "Total identified from the precipitation event preceding this inspection",
+} as const;
+
+// --- Section 1: Conditional question prompts (official p.1) ---
+
+export const NDOT_SECTION1_PROMPTS = {
+  tmdl_waterway:
+    "Is there a potential for construction stormwater runoff to discharge into an impaired or TMDL listed waterway? (See SWPPP)",
+  tmdl_waterway_names: "If yes, which waterway(s):",
+  deficiency_followup:
+    "Were deficiencies identified during the previous inspection? If yes, describe the corrective action(s) implemented, or the steps taken in the non-compliance escalation process.",
+  erosion_evidence:
+    "Are there areas exhibiting significant erosion (rills, gullies, sheet erosion, etc.) as a result from construction activities?",
+  erosion_discharge: "If yes, do any of these areas discharge into a waterway?",
+  erosion_waterway: "If yes, which waterway(s) (if name is known)?",
+  adjacent_runoff: "Is stormwater runoff being discharged onto the project area from adjacent areas?",
+  pollutant_concerns:
+    "Are there any noticeable pollutant-related concerns regarding stormwater discharging from and/or onto the project area? If yes, briefly explain.",
+} as const;
+
+// --- Section 1: SWPPP element prompts (official p.1) ---
+
+export const NDOT_SWPPP_PROMPTS = {
+  swppp_onsite: "Is the SWPPP onsite & available?",
+  swppp_signed: "Is the SWPPP signed and certified?",
+  swppp_current: "Is the SWPPP complete and up-to-date?",
+  swppp_posted: "Is the Construction General Permit information properly posted at the construction site?",
+} as const;
+
+// --- Section 3: Batch plants / Illicit discharge / Final check prompts (official p.3) ---
+
+export const NDOT_SECTION3_PROMPTS = {
+  batch_plant_present:
+    "Are there temporary batch plants associated with the project? If no, proceed to next sub-section.",
+  batch_plant_location: "Location of temporary batch plants?",
+  illicit_discharges: "Are there any illicit discharges? If yes, briefly describe the discharge in question.",
+  reportable_spills:
+    "Are there any spills meeting the reportable quantity threshold for the current inspection period? If yes, briefly describe the spill in question.",
+  spill_action: "Was appropriate action taken to address the illicit discharge or spill?",
+  ndep_report_filed: "Was a spill report filed with NDEP?",
+  non_reportable_spills:
+    "Was a non-reportable spill report completed during the inspection period? If yes, briefly describe the spill and actions taken.",
+  all_areas_inspected:
+    "Were all non-stabilized and construction staging areas inspected? If no, provide a brief explanation.",
+  non_structural_bmps:
+    "Have non-structural BMPs been implemented during the inspection period (i.e. Sweeping, drip pan, equipment diapers, etc.)? If yes, briefly describe.",
+} as const;

--- a/src/lib/pdf/ndot-stormwater.tsx
+++ b/src/lib/pdf/ndot-stormwater.tsx
@@ -5,7 +5,6 @@ import {
   Section,
   FieldRow,
   Field,
-  YNField,
   YN,
   SignatureBlock,
   Certification,
@@ -13,6 +12,14 @@ import {
   colors,
 } from "./primitives";
 import type { NdotStormwaterData } from "@/lib/schemas/ndot-stormwater";
+import {
+  NDOT_INSTRUCTIONS,
+  NDOT_CERT_TEXT,
+  NDOT_BMP_PROMPTS,
+  NDOT_SECTION1_PROMPTS,
+  NDOT_SWPPP_PROMPTS,
+  NDOT_SECTION3_PROMPTS,
+} from "@/lib/constants/ndot-form-text";
 
 interface Props {
   data: NdotStormwaterData;
@@ -35,10 +42,26 @@ const INTENSITY_LABELS: Record<string, string> = {
   heavy: "Heavy",
 };
 
-const CERT_TEXT =
-  "I certify under penalty of law that this document and all attachments were prepared under my direction or supervision in accordance with a system designed to assure that qualified personnel properly gathered and evaluated the information submitted. Based on my inquiry of the person or persons who manage the system, or those persons directly responsible for gathering the information, the information submitted is, to the best of my knowledge and belief, true, accurate, and complete. I am aware that there are significant penalties for submitting false information, including the possibility of fine and imprisonment for knowing violations. 40 CFR 122.22(d)";
-
 const FORM_ID = "FORM 018-001 WPCM (Rev. 1/04/2017)";
+
+// Full-width "prompt + Y/N" row mirroring the official form's vertical layout.
+// `detail` renders the conditional follow-up answer (waterway names, actions, etc.)
+// beneath the prompt when present.
+function PromptRow({ prompt, value, detail }: { prompt: string; value?: string; detail?: string }) {
+  return (
+    <View style={{ marginBottom: 5 }}>
+      <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" }}>
+        <Text style={{ flex: 1, fontSize: 8, paddingRight: 8 }}>{prompt}</Text>
+        <View style={{ flexShrink: 0 }}>
+          <YN value={value} />
+        </View>
+      </View>
+      {detail ? (
+        <Text style={{ fontSize: 7.5, color: colors.muted, marginTop: 1 }}>{detail}</Text>
+      ) : null}
+    </View>
+  );
+}
 
 function PageFooter() {
   return (
@@ -82,6 +105,12 @@ export function NdotStormwaterPdf({ data, projectName, permitNumber, formDate }:
       {/* PAGE 1 — Site Info + Conditions + SWPPP + first BMPs */}
       <Page size="LETTER" style={s.page}>
         <NdotHeader />
+
+        {/* Instructions (official p.1) */}
+        <Text style={{ fontSize: 7, color: colors.muted, marginBottom: 6, lineHeight: 1.3 }}>
+          <Text style={s.bold}>Instructions: </Text>
+          {NDOT_INSTRUCTIONS}
+        </Text>
 
         {/* Site Information */}
         <Section title="Site Information" />
@@ -128,41 +157,47 @@ export function NdotStormwaterPdf({ data, projectName, permitNumber, formDate }:
 
         {/* Assessment Questions */}
         <Section title="Site Assessment" />
-        <FieldRow>
-          <YNField label="TMDL Waterway Potential?" value={data.tmdl_waterway} />
-          <Field label="Waterway Names" value={data.tmdl_waterway_names} />
-        </FieldRow>
-        <FieldRow>
-          <YNField label="Significant Erosion?" value={data.erosion_evidence} />
-          <YNField label="Discharge into Waterway?" value={data.erosion_discharge} />
-          <Field label="Which Waterway" value={data.erosion_waterway} />
-        </FieldRow>
-        <FieldRow>
-          <YNField label="Adjacent Stormwater?" value={data.adjacent_runoff} />
-          <YNField label="Pollutant Concerns?" value={data.pollutant_concerns} />
-        </FieldRow>
-        <FieldRow>
-          <Field
-            label="Deficiency Follow-up"
-            value={
-              data.deficiency_followup === "yes"
-                ? "Yes"
-                : data.deficiency_followup === "no"
-                  ? "No"
-                  : "N/A"
-            }
-          />
-          <Field label="Actions Taken" value={data.deficiency_actions} />
-        </FieldRow>
+        <PromptRow
+          prompt={NDOT_SECTION1_PROMPTS.tmdl_waterway}
+          value={data.tmdl_waterway}
+          detail={
+            data.tmdl_waterway === "Y" && data.tmdl_waterway_names
+              ? `${NDOT_SECTION1_PROMPTS.tmdl_waterway_names} ${data.tmdl_waterway_names}`
+              : undefined
+          }
+        />
+        {/* Deficiency follow-up: N/A | Yes | No */}
+        <View style={{ marginBottom: 5 }}>
+          <Text style={{ fontSize: 8 }}>{NDOT_SECTION1_PROMPTS.deficiency_followup}</Text>
+          <Text style={{ fontSize: 7.5, color: colors.muted, marginTop: 1 }}>
+            {data.deficiency_followup === "yes" ? "Yes" : data.deficiency_followup === "no" ? "No" : "N/A"}
+            {data.deficiency_actions ? ` — ${data.deficiency_actions}` : ""}
+          </Text>
+        </View>
+        <PromptRow
+          prompt={NDOT_SECTION1_PROMPTS.erosion_evidence}
+          value={data.erosion_evidence}
+          detail={
+            data.erosion_evidence === "Y"
+              ? `${NDOT_SECTION1_PROMPTS.erosion_discharge} ${data.erosion_discharge ?? "—"}${
+                  data.erosion_waterway ? ` · ${data.erosion_waterway}` : ""
+                }`
+              : undefined
+          }
+        />
+        <PromptRow prompt={NDOT_SECTION1_PROMPTS.adjacent_runoff} value={data.adjacent_runoff} />
+        <PromptRow
+          prompt={NDOT_SECTION1_PROMPTS.pollutant_concerns}
+          value={data.pollutant_concerns}
+          detail={data.pollutant_concerns === "Y" ? data.pollutant_explain : undefined}
+        />
 
         {/* SWPPP Elements */}
         <Section title="SWPPP Elements" />
-        <FieldRow>
-          <YNField label="SWPPP Onsite?" value={data.swppp_onsite} />
-          <YNField label="SWPPP Signed?" value={data.swppp_signed} />
-          <YNField label="SWPPP Current?" value={data.swppp_current} />
-          <YNField label="Permit Posted?" value={data.swppp_posted} />
-        </FieldRow>
+        <PromptRow prompt={NDOT_SWPPP_PROMPTS.swppp_onsite} value={data.swppp_onsite} />
+        <PromptRow prompt={NDOT_SWPPP_PROMPTS.swppp_signed} value={data.swppp_signed} />
+        <PromptRow prompt={NDOT_SWPPP_PROMPTS.swppp_current} value={data.swppp_current} />
+        <PromptRow prompt={NDOT_SWPPP_PROMPTS.swppp_posted} value={data.swppp_posted} />
 
         <PageFooter />
       </Page>
@@ -172,62 +207,64 @@ export function NdotStormwaterPdf({ data, projectName, permitNumber, formDate }:
         <NdotHeader />
         <Section title="Best Management Practice (BMP) Categories" />
 
-        <View style={s.tableHeaderRow}>
-          <Text style={[s.tableCellBold, { width: "35%" }]}>BMP Category</Text>
-          <Text style={[s.tableCellBold, { width: "15%", textAlign: "center" }]}>Required?</Text>
-          <Text style={[s.tableCellBold, { width: "15%", textAlign: "center" }]}>Implemented?</Text>
-          <Text style={[s.tableCellBold, { width: "35%" }]}>Comments</Text>
-        </View>
-
-        {bmps.map((bmp, i) => (
-          <View key={i} style={s.tableRow}>
-            <Text style={[s.tableCell, { width: "35%" }]}>{bmp.name}</Text>
-            <View style={{ width: "15%", alignItems: "center", paddingVertical: 3 }}>
-              <YN value={bmp.required} />
+        {bmps.map((bmp, i) => {
+          const prompt = NDOT_BMP_PROMPTS[bmp.name as keyof typeof NDOT_BMP_PROMPTS];
+          return (
+            <View
+              key={i}
+              wrap={false}
+              style={{ marginBottom: 7, paddingBottom: 4, borderBottomWidth: 0.5, borderBottomColor: "#D1D5DB" }}
+            >
+              <Text style={[s.bold, { fontSize: 9, marginBottom: 2 }]}>
+                {prompt?.displayName ?? bmp.name}
+              </Text>
+              <PromptRow prompt={prompt?.required ?? "Required?"} value={bmp.required} />
+              <PromptRow prompt={prompt?.implemented ?? "Are BMPs properly implemented?"} value={bmp.implemented} />
+              {bmp.comments ? (
+                <Text style={{ fontSize: 7.5, color: colors.muted }}>Comments: {bmp.comments}</Text>
+              ) : null}
             </View>
-            <View style={{ width: "15%", alignItems: "center", paddingVertical: 3 }}>
-              <YN value={bmp.implemented} />
-            </View>
-            <Text style={[s.tableCell, { width: "35%" }]}>{bmp.comments || "---"}</Text>
-          </View>
-        ))}
+          );
+        })}
 
         {/* Batch Plants */}
         <Section title="Temporary Batch Plants" />
-        <FieldRow>
-          <YNField label="Batch Plant Present?" value={data.batch_plant_present} />
-          <Field
-            label="Location"
-            value={data.batch_plant_location === "onsite" ? "Onsite" : data.batch_plant_location === "offsite" ? "Offsite" : "---"}
-          />
-        </FieldRow>
-        {data.batch_plant_comments && (
-          <View style={s.mb4}>
-            <Text style={[s.bold, { fontSize: 7, color: colors.label }]}>Comments</Text>
-            <Text>{data.batch_plant_comments}</Text>
-          </View>
-        )}
+        <PromptRow
+          prompt={NDOT_SECTION3_PROMPTS.batch_plant_present}
+          value={data.batch_plant_present}
+          detail={
+            data.batch_plant_present === "Y"
+              ? `${NDOT_SECTION3_PROMPTS.batch_plant_location} ${
+                  data.batch_plant_location === "onsite"
+                    ? "Onsite"
+                    : data.batch_plant_location === "offsite"
+                      ? "Offsite"
+                      : "—"
+                }${data.batch_plant_comments ? ` · ${data.batch_plant_comments}` : ""}`
+              : undefined
+          }
+        />
 
         {/* Illicit Discharge */}
-        <Section title="Illicit Discharge Detection & Spill Response" />
-        <FieldRow>
-          <YNField label="Illicit Discharges?" value={data.illicit_discharges} />
-          <YNField label="Reportable Spills?" value={data.reportable_spills} />
-          <YNField label="NDEP Report Filed?" value={data.ndep_report_filed} />
-          <YNField label="Non-reportable Spills?" value={data.non_reportable_spills} />
-        </FieldRow>
-        {data.spill_action && (
-          <View style={s.mb4}>
-            <Text style={[s.bold, { fontSize: 7, color: colors.label }]}>Spill Actions</Text>
-            <Text>{data.spill_action}</Text>
-          </View>
-        )}
+        <Section title="Illicit Discharge Detection and Elimination / Spill Response" />
+        <PromptRow prompt={NDOT_SECTION3_PROMPTS.illicit_discharges} value={data.illicit_discharges} />
+        <PromptRow prompt={NDOT_SECTION3_PROMPTS.reportable_spills} value={data.reportable_spills} />
+        <View style={{ marginBottom: 5 }}>
+          <Text style={{ fontSize: 8 }}>{NDOT_SECTION3_PROMPTS.spill_action}</Text>
+          <Text style={{ fontSize: 7.5, color: colors.muted, marginTop: 1 }}>{data.spill_action || "N/A"}</Text>
+        </View>
+        <PromptRow prompt={NDOT_SECTION3_PROMPTS.ndep_report_filed} value={data.ndep_report_filed} />
+        <PromptRow prompt={NDOT_SECTION3_PROMPTS.non_reportable_spills} value={data.non_reportable_spills} />
 
         {/* Final Check */}
         <Section title="Final Check" />
-        <FieldRow>
-          <YNField label="All Areas Inspected?" value={data.all_areas_inspected} />
-        </FieldRow>
+        <PromptRow prompt={NDOT_SECTION3_PROMPTS.all_areas_inspected} value={data.all_areas_inspected} />
+        <View style={{ marginBottom: 5 }}>
+          <Text style={{ fontSize: 8 }}>{NDOT_SECTION3_PROMPTS.non_structural_bmps}</Text>
+          {data.non_structural_bmps ? (
+            <Text style={{ fontSize: 7.5, color: colors.muted, marginTop: 1 }}>{data.non_structural_bmps}</Text>
+          ) : null}
+        </View>
 
         <PageFooter />
       </Page>
@@ -260,7 +297,7 @@ export function NdotStormwaterPdf({ data, projectName, permitNumber, formDate }:
         )}
 
         {/* Certification + Signatures */}
-        <Certification text={CERT_TEXT} />
+        <Certification text={NDOT_CERT_TEXT} />
         <View style={s.signatureBlock}>
           <SignatureBlock label="Inspector" name={data.inspector_name} date={data.inspector_date} />
           <SignatureBlock label="Water Pollution Control Manager" name={data.wpcm_name} date={data.wpcm_date} />


### PR DESCRIPTION
## BF-51 — Mirror official NDOT form explanatory text

UAT Round 4 headline ask (Gracie Damele via Andy). NDOT reviewers are picky about the digital form **looking** like the official Form 018-001 WPCM. Deep research against the official PDF (`Testing/NDOT Weekly Stormwater Logs.pdf`) + Gracie's annotations showed the ask is **form-wide**, not just the BMP table.

### Scope: full parity (A+B+C)
- **Single source of truth** — new `src/lib/constants/ndot-form-text.ts` holds every official string verbatim (instructions, certification, BMP prompts, Section 1 / SWPPP / Section 3 prompts), keyed by field/category. All four render surfaces import from it.
- **Entry form (new + edit)** — BMP prompts under each category with `aria-describedby`; full official prompts on Section 1 conditional questions, SWPPP elements, and Section 3; Instructions paragraph at top.
- **Read-only view page** — BMP prompts + Section 1/3 full prompts + canonical cert.
- **PDF (the artifact NDOT receives)** — rewritten to the official vertical layout: Instructions block, BMP as vertical prompt blocks, Y/N sections as full-width prompt+Y/N rows; added the missing non-reportable-spill and non-structural-BMP prompts. Page growth past 3 sheets accepted.

### Certification fix
The prior story claim that the 40 CFR 122.22(d) cert "already matches" was wrong — three divergent hand-typed variants existed (entry/view/PDF). All three now render one `NDOT_CERT_TEXT`, verbatim including the comma after "law" and the `[40 CFR 122.22(d)]` brackets.

### Safety
Presentational only — no schema, no migration. Prompts key off the stored `bmp_categories[].name`, so existing submissions render unchanged.

### Verification
- ESLint: 0 errors (8 pre-existing warnings, none in changed logic)
- `next build`: clean — type-check passed, all routes compiled

### Open AC
Tablet/mobile reflow not verified without a device — deferred to Andy/Gracie UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
